### PR TITLE
Use sanitize_headers plugin by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased][]
 
 ### Changed
 
-- The `dump`, `dumps`, and `transform` functions by default use the
+  - The `dump`, `dumps`, and `transform` functions by default use the
   `sanitize_headers` plugin even if users don't provide it in the plugin list.
   This is because the resulting locustfile would almost certainly be broken
   without these plugins. Users can still opt-out from these default plugins
@@ -18,40 +18,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `transformer.transform.{dump,dumps}`: Similar to `json.{dump,dumps}`, these
+  - `transformer.transform.{dump,dumps}`: Similar to `json.{dump,dumps}`, these
   high-level functions should be all most users need to know about Transformer.
   They convert lists of scenario paths and plugins into a final locustfile.
   They will replace the `transform` function, which requires more familiarity
   with Transformer's internals. (#14)
-- `transformer.locust.locustfile_lines`: Similar to `locustfile` but returns
+  - `transformer.locust.locustfile_lines`: Similar to `locustfile` but returns
   an iterator over lines (as strings) instead of a string containing the full
   locustfile. This design allows for more flexibility in `dump`/`dumps` and
   should result in smaller memory usage for huge locustfiles. (#14)
 
 ### Deprecated
 
-- `transformer.transform.transform` (#14)
-- `transformer.locust.locustfile` (#14)
+  - `transformer.transform.transform` (#14)
+  - `transformer.locust.locustfile` (#14)
 
 ## [1.0.1] - 2019-02-12
 
 ### Fixed
 
-- Fix `transformer` command-line crash due to a missing version identifier. (#17)
-- Publish development releases to PyPI for every merge to the `master` branch. (#17)
+  - Fix `transformer` command-line crash due to a missing version identifier. (#17)
+  - Publish development releases to PyPI for every merge to the `master` branch. (#17)
 
 ## [1.0.0] - 2019-02-11
 
 ### Added
 
-- Plugin contracts aiming to eventually deprecate OnTaskSequence:
+  - Plugin contracts aiming to eventually deprecate OnTaskSequence:
   OnTask, OnScenario, OnPythonProgram.
-- Transformer can now be called using a `transformer` script installed by
+  - Transformer can now be called using a `transformer` script installed by
   `pip`, or via `python -m transformer`. (#7)
-- Transformer is now published to PyPI as [`har-transformer`] (it looks like
+  - Transformer is now published to PyPI as [`har-transformer`] (it looks like
   the name `transformer` is already taken, unsurprisingly). (#3)
-- Remove Pipenv completely; everything uses [Poetry] now.
-- Add a general `transformer.plugins.contracts.Plugin` type covering all more
+  - Remove Pipenv completely; everything uses [Poetry] now.
+  - Add a general `transformer.plugins.contracts.Plugin` type covering all more
   specialized plugin types, like `OnTask`, `OnTaskSequence`, etc.
 
 [har-transformer]: https://pypi.org/project/har-transformer
@@ -59,8 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Open-sourcing of this project in https://github.com/zalando-incubator.
-- `transformer.plugins.Plugin` is renamed
+  - Open-sourcing of this project in https://github.com/zalando-incubator.
+  - `transformer.plugins.Plugin` is renamed
   `transformer.plugins.contracts.OnTaskSequence`.
 
 [Unreleased]: https://github.com/zalando-incubator/transformer/compare/v1.0.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!--
 ## [Unreleased]
--->
+
+### Changed
+
+- The `dump`, `dumps`, and `transform` functions by default use the
+  `sanitize_headers` plugin even if users don't provide it in the plugin list.
+  This is because the resulting locustfile would almost certainly be broken
+  without these plugins. Users can still opt-out from these default plugins
+  by passing the keyword-argument `with_default_plugins=False` (e.g. if they
+  implemented their own version). (#14)
+
+### Added
+
+- `transformer.transform.{dump,dumps}`: Similar to `json.{dump,dumps}`, these
+  high-level functions should be all most users need to know about Transformer.
+  They convert lists of scenario paths and plugins into a final locustfile.
+  They will replace the `transform` function, which requires more familiarity
+  with Transformer's internals. (#14)
+- `transformer.locust.locustfile_lines`: Similar to `locustfile` but returns
+  an iterator over lines (as strings) instead of a string containing the full
+  locustfile. This design allows for more flexibility in `dump`/`dumps` and
+  should result in smaller memory usage for huge locustfiles. (#14)
+
+### Deprecated
+
+- `transformer.transform.transform` (#14)
+- `transformer.locust.locustfile` (#14)
 
 ## [1.0.1] - 2019-02-12
 
@@ -35,7 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The plugin `sanitize_headers` is now used by default.
 - Open-sourcing of this project in https://github.com/zalando-incubator.
 - `transformer.plugins.Plugin` is renamed
   `transformer.plugins.contracts.OnTaskSequence`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The plugin `sanitize_headers` is now used by default.
 - Open-sourcing of this project in https://github.com/zalando-incubator.
 - `transformer.plugins.Plugin` is renamed
   `transformer.plugins.contracts.OnTaskSequence`.

--- a/common.mk
+++ b/common.mk
@@ -13,7 +13,7 @@ configure: .make/configure
 # Runs pytest with coverage reporting.
 .PHONY: test
 test: configure
-	poetry run pytest --cov-config .coveragerc --cov-report xml --cov=. transformer/
+	poetry run pytest --failed-first --cov-config .coveragerc --cov-report xml --cov=. transformer/
 
 .PHONY: lint
 lint: black flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "har-transformer"
-version = "1.0.1"
+version = "1.0.2"
 description = "A tool to convert HAR files into a locustfile."
 authors = [
     "Serhii Cherniavskyi <serhii.cherniavskyi@zalando.de>",

--- a/transformer/__init__.py
+++ b/transformer/__init__.py
@@ -1,3 +1,6 @@
 import pkg_resources
+from .transform import dumps, dump
 
 __version__ = pkg_resources.get_distribution("har-transformer").version
+
+__all__ = ["dumps", "dump"]

--- a/transformer/locust.py
+++ b/transformer/locust.py
@@ -1,5 +1,6 @@
 import enum
-from typing import Sequence, List, Union
+import warnings
+from typing import Sequence, List, Union, Iterator
 
 import transformer.python as py
 from transformer.scenario import Scenario
@@ -118,7 +119,25 @@ def locust_program(scenarios: Sequence[Scenario]) -> py.Program:
     ]
 
 
+def locustfile_lines(scenarios: Sequence[Scenario]) -> Iterator[str]:
+    """
+    Converts the provided scenarios into a stream of Python statements
+    and iterate on the resulting lines.
+    """
+    for stmt in locust_program(scenarios):
+        for line in stmt.lines():
+            yield str(line)
+
+
 def locustfile(scenarios: Sequence[Scenario]) -> str:
-    return "\n".join(
-        str(line) for stmt in locust_program(scenarios) for line in stmt.lines()
-    )
+    """
+    Simple wrapper around locustfile_lines joining all lines with "\n".
+
+    This function is deprecated and will be removed in a future version.
+    Do not rely on it.
+    Reason: It does not provide significant value over locustfile_lines and has
+    a less clear name and a less flexible API.
+    Deprecated since: v1.0.2.
+    """
+    warnings.warn(DeprecationWarning("locustfile: use locustfile_lines instead"))
+    return "\n".join(locustfile_lines(scenarios))

--- a/transformer/plugins/README.md
+++ b/transformer/plugins/README.md
@@ -2,7 +2,7 @@
 
 ## List of available plugins
 
-- [`sanitize_headers`](sanitize_headers.md)
+- [`sanitize_headers`](sanitize_headers.md) - used by default
 
 ## How to use plugins
 
@@ -18,6 +18,9 @@ from transformer.plugins import sanitize_headers
 paths = [...]
 locustfile = transform.main(paths, plugins=[sanitize_headers.plugin])
 ```
+
+Please note that the example above only aims to illustrate how to use a plugin.
+There's no need to specifically use the `sanitize_headers` plugin, because it's used by default anyway.
 
 [`Plugin`]: __init__.py
 [`sanitize_headers`]: sanitize_headers.py

--- a/transformer/plugins/README.md
+++ b/transformer/plugins/README.md
@@ -1,42 +1,81 @@
 # Plugins
 
+<!-- toc -->
+
+- [List of available plugins](#list-of-available-plugins)
+- [How to use plugins](#how-to-use-plugins)
+  * [From the command-line](#from-the-command-line)
+  * [When using Transformer as a library](#when-using-transformer-as-a-library)
+- [Writing custom plugins](#writing-custom-plugins)
+  * [Implementation](#implementation)
+  * [Name resolution](#name-resolution)
+
+<!-- tocstop -->
+
 ## List of available plugins
 
-- [`sanitize_headers`](sanitize_headers.md) - used by default
+[sanitize_headers]: sanitize_headers.md
+
+  - [`transformer.plugins.sanitize_headers`][sanitize_headers] - used by default
 
 ## How to use plugins
 
-In order to use a plugin, pass a method of a [`Plugin`](__init__.py) signature:
-- a single argument of type `Sequence[Task]`
-- returned value of type `Sequence[Task]`
+### From the command-line
 
-to the `transform.main` function like so:
-```python
-from transformer import transform
-from transformer.plugins import sanitize_headers
+Use the `-p`/`--plugin` command-line option associated to a plugin name
+(possibly repeatedly):
 
-paths = [...]
-locustfile = transform.main(paths, plugins=[sanitize_headers.plugin])
+```bash
+$ transformer -p transformer.plugins.sanitize_headers ...
 ```
 
-Please note that the example above only aims to illustrate how to use a plugin.
-There's no need to specifically use the `sanitize_headers` plugin, because it's used by default anyway.
+Use `transformer --help` or just `transformer` for more details about
+the command-line documentation.
 
-[`Plugin`]: __init__.py
-[`sanitize_headers`]: sanitize_headers.py
+### When using Transformer as a library
+
+Use the `dump` or `dumps` method and provide the names of the plugins you want
+to use as the `plugins` argument:
+
+```python
+from sys import stdout
+import transformer
+
+scenarios = [...]
+transformer.dump(stdout, scenarios, plugins=["transformer.plugins.sanitize_headers"])
+```
+
+Note that the above example only aims to illustrate how to use a plugin.
+There's no need to specifically use the `sanitize_headers` plugin,
+because it's used by default anyway.
 
 ## Writing custom plugins
 
-It's possible to use custom plugins. A valid plugin must be a method with the signature of the [`Plugin`][].
+If the plugins that come with Transformer or that you can find on PyPI don't
+cover your use-cases, you can implement and use your own plugin.
 
-Each plugin has access to all `Task`s that are generated from the HAR file, and can modify them in different way,
-depending on the intent:
-- the `locust_request` attribute can be modified in order to change the request itself, e.g. its URL or parameters,
-- the `locust_preprocessing` attribute can be modified in order to add some logic **before** the request,
-- the `locust_postprocessing` attribute can be modified in order to add some logic **after** the request;
-  at this stage, the `response` object from the request can also be used.
+### Implementation
 
-Each plugin must take a full collection of tasks (`Sequence[Task]`) as argument, and return it as well,
-which means that both: modified and untouched tasks should be returned, with respect to their order.
+A Transformer plugin is a Python function with a specific constraints:
 
-See [`sanitize_headers`][] plugin as an example of the implementation.
+  - its name must begin with `plugin` (examples: `plugin`, `plugin_x`);
+  - it must use Python's [type hints syntax](https://www.python.org/dev/peps/pep-0484/);
+  - its parameters and return value (as specified by its type hints) must match
+    those defined by [one of the _Plugin_ subtypes](contracts.py).
+
+See the [`sanitize_headers`][] plugin as an example.
+
+### Name resolution
+
+Let's say the `mod/sub.py` file contains a function called `plugin_f`
+implementing the constraints listed in the previous section.
+
+Let's also assume that your Python import path is configured so that you can
+execute `from mod.sub import plugin` successfully.
+
+You can use this custom plugin by passing its name to Transformer.
+Your plugin's name is **not** the name of the function (`plugin_f`)
+but the name of the module containing it (`mod.sub`).
+
+This means that you can have multiple "plugin functions" (`plugin_f`,
+`plugin_postprocessing`, etc.) under the same plugin name.

--- a/transformer/test_transform.py
+++ b/transformer/test_transform.py
@@ -1,20 +1,32 @@
 # pylint: skip-file
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-import transformer.transform
+import transformer.transform as tt
+from transformer.transform import DEFAULT_PLUGINS
 from transformer.helpers import _DUMMY_HAR_DICT
 
 
 class TestTransform:
-    def test_it_returns_a_locustfile_string_given_scenario_path(self, tmp_path: Path):
+    def test_it_returns_a_locustfile_program_given_scenario_path(self, tmp_path: Path):
         har_path = tmp_path / "some.har"
         with har_path.open("w") as file:
             json.dump(_DUMMY_HAR_DICT, file)
-        locustfile_contents = str(transformer.transform.transform(har_path))
+        locustfile_contents = str(tt.transform(har_path))
         try:
             compile(locustfile_contents, "locustfile.py", "exec")
         except Exception as exception:
             pytest.fail(f"Compiling locustfile failed. [{exception}].")
+
+    @patch("transformer.transform.locustfile")
+    @patch("transformer.transform.Scenario.from_path")
+    def test_it_uses_default_plugins(self, scenario_from_path, _, tmp_path: Path):
+        har_path = tmp_path / "some.har"
+        with har_path.open("w") as file:
+            json.dump(_DUMMY_HAR_DICT, file)
+
+        tt.transform(har_path)
+        scenario_from_path.assert_called_once_with(har_path, DEFAULT_PLUGINS)

--- a/transformer/test_transform.py
+++ b/transformer/test_transform.py
@@ -1,21 +1,19 @@
 # pylint: skip-file
 import io
-import json
 from pathlib import Path
 
 import pytest
 
 import transformer
 import transformer.transform as tt
-from transformer.helpers import _DUMMY_HAR_DICT
+from transformer.helpers import DUMMY_HAR_STRING
 from transformer.locust import locustfile_lines
 
 
 class TestTransform:
     def test_it_returns_a_locustfile_program_given_scenario_path(self, tmp_path: Path):
         har_path = tmp_path / "some.har"
-        with har_path.open("w") as file:
-            json.dump(_DUMMY_HAR_DICT, file)
+        har_path.write_text(DUMMY_HAR_STRING)
         locustfile_contents = str(tt.transform(har_path))
         try:
             compile(locustfile_contents, "locustfile.py", "exec")
@@ -24,8 +22,7 @@ class TestTransform:
 
     def test_it_uses_default_plugins(self, tmp_path: Path, monkeypatch):
         har_path = tmp_path / "some.har"
-        with har_path.open("w") as file:
-            json.dump(_DUMMY_HAR_DICT, file)
+        har_path.write_text(DUMMY_HAR_STRING)
 
         times_plugin_called = 0
 
@@ -63,8 +60,7 @@ class TestDumpAndDumps:
 
     def test_dump_and_dumps_have_same_output_for_simple_har(self, tmp_path):
         har_path = tmp_path / "some.har"
-        with har_path.open("w") as file:
-            json.dump(_DUMMY_HAR_DICT, file)
+        har_path.write_text(DUMMY_HAR_STRING)
 
         assert transformer.dumps([tmp_path]) == dump_as_str([tmp_path])
 
@@ -80,8 +76,7 @@ class TestDumpAndDumps:
         self, tmp_path: Path, monkeypatch, f, with_default, expected_times_called
     ):
         har_path = tmp_path / "some.har"
-        with har_path.open("w") as file:
-            json.dump(_DUMMY_HAR_DICT, file)
+        har_path.write_text(DUMMY_HAR_STRING)
 
         times_plugin_called = 0
 

--- a/transformer/transform.py
+++ b/transformer/transform.py
@@ -7,11 +7,15 @@ from typing import Sequence, Union
 
 import transformer.python as py
 from transformer.locust import locustfile
+from transformer.plugins import sanitize_headers
 from transformer.plugins.contracts import OnTaskSequence
 from transformer.scenario import Scenario
+
+DEFAULT_PLUGINS = [sanitize_headers.plugin]
 
 
 def transform(
     scenarios_path: Union[str, Path], plugins: Sequence[OnTaskSequence] = ()
 ) -> py.Program:
-    return locustfile([Scenario.from_path(Path(scenarios_path), plugins)])
+    actual_plugins = [*DEFAULT_PLUGINS, *plugins]
+    return locustfile([Scenario.from_path(Path(scenarios_path), actual_plugins)])

--- a/transformer/transform.py
+++ b/transformer/transform.py
@@ -10,7 +10,7 @@ from transformer.plugins import sanitize_headers
 from transformer.plugins.contracts import OnTaskSequence
 from transformer.scenario import Scenario
 
-DEFAULT_PLUGINS = [sanitize_headers.plugin]
+DEFAULT_PLUGINS = (sanitize_headers.plugin,)
 
 
 def transform(

--- a/transformer/transform.py
+++ b/transformer/transform.py
@@ -40,7 +40,7 @@ PluginName = str
 
 def dumps(
     scenario_paths: Iterable[LaxPath],
-    plugins: Sequence[PluginName],
+    plugins: Sequence[PluginName] = (),
     with_default_plugins: bool = True,
 ) -> str:
     """
@@ -60,7 +60,7 @@ def dumps(
 def dump(
     file: TextIO,
     scenario_paths: Iterable[LaxPath],
-    plugins: Sequence[PluginName],
+    plugins: Sequence[PluginName] = (),
     with_default_plugins: bool = True,
 ) -> None:
     """
@@ -80,7 +80,7 @@ def dump(
 def _dump_as_lines(
     scenario_paths: Iterable[LaxPath],
     plugins: Sequence[PluginName],
-    with_default_plugins: bool = True,
+    with_default_plugins: bool,
 ) -> Iterator[str]:
     if with_default_plugins:
         plugins = (*DEFAULT_PLUGINS, *plugins)

--- a/transformer/transform.py
+++ b/transformer/transform.py
@@ -108,7 +108,10 @@ def intersperse(delim: T, iterable: Iterable[T]) -> Iterator[T]:
     ['a', ',', 'b', ',', 'c']
     """
     it = iter(iterable)
-    yield next(it)
+    try:
+        yield next(it)
+    except StopIteration:
+        return
     for x in it:
         yield delim
         yield x

--- a/transformer/transform.py
+++ b/transformer/transform.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
 """
-Entrypoint for Transformer.
+Entrypoint for Transformer when used as a library.
 """
+import warnings
 from pathlib import Path
-from typing import Sequence, Union
+from typing import Sequence, Union, Iterable, TextIO, Iterator
 
-import transformer.python as py
-from transformer.locust import locustfile
+from transformer.locust import locustfile, locustfile_lines
 from transformer.plugins import sanitize_headers
 from transformer.plugins.contracts import OnTaskSequence
 from transformer.scenario import Scenario
@@ -15,7 +14,76 @@ DEFAULT_PLUGINS = [sanitize_headers.plugin]
 
 
 def transform(
-    scenarios_path: Union[str, Path], plugins: Sequence[OnTaskSequence] = ()
-) -> py.Program:
-    actual_plugins = [*DEFAULT_PLUGINS, *plugins]
-    return locustfile([Scenario.from_path(Path(scenarios_path), actual_plugins)])
+    scenarios_path: Union[str, Path],
+    plugins: Sequence[OnTaskSequence] = (),
+    with_default_plugins: bool = True,
+) -> str:
+    """
+    This function is deprecated and will be removed in a future version.
+    Do not rely on it.
+    Reason: It only accepts one scenario path at a time, and requires plugins
+    to be already resolved (and therefore that users use
+    transformer.plugins.resolve, which is kind of low-level). Both dumps & dump
+    lift these constraints and have a more familiar naming
+    (see json.dump/s, etc.).
+    Deprecated since: v1.0.2.
+    """
+    warnings.warn(DeprecationWarning("transform: use dump or dumps instead"))
+    if with_default_plugins:
+        plugins = (*DEFAULT_PLUGINS, *plugins)
+    return locustfile([Scenario.from_path(Path(scenarios_path), plugins)])
+
+
+LaxPath = Union[str, Path]
+PluginName = str
+
+
+def dumps(
+    scenario_paths: Iterable[LaxPath],
+    plugins: Sequence[PluginName],
+    with_default_plugins: bool = True,
+) -> str:
+    """
+    Transforms the provided scenarios using the provided plugins, and returns
+    the resulting locustfile code as a string.
+
+    See also: dump
+
+    :param scenario_paths: paths to scenario files (HAR) or directories
+    :param plugins: names of plugins to use
+    :param with_default_plugins: whether the default plugins should be used in
+        addition to those provided (recommended: True)
+    """
+    return "\n".join(_dump_as_lines(scenario_paths, plugins, with_default_plugins))
+
+
+def dump(
+    file: TextIO,
+    scenario_paths: Iterable[LaxPath],
+    plugins: Sequence[PluginName],
+    with_default_plugins: bool = True,
+) -> None:
+    """
+    Transforms the provided scenarios using the provided plugins, and writes
+    the resulting locustfile code in the provided file.
+
+    See also: dumps
+
+    :param scenario_paths: paths to scenario files (HAR) or directories
+    :param plugins: names of plugins to use
+    :param with_default_plugins: whether the default plugins should be used in
+        addition to those provided (recommended: True)
+    """
+    file.writelines(_dump_as_lines(scenario_paths, plugins, with_default_plugins))
+
+
+def _dump_as_lines(
+    scenario_paths: Iterable[LaxPath],
+    plugins: Sequence[PluginName],
+    with_default_plugins: bool = True,
+) -> Iterator[str]:
+    if with_default_plugins:
+        plugins = (*DEFAULT_PLUGINS, *plugins)
+    yield from locustfile_lines(
+        [Scenario.from_path(path, plugins) for path in scenario_paths]
+    )


### PR DESCRIPTION
Signed-off-by: Oliwia Zaremba <oliwia.zaremba@zalando.de>

# Use the plugin `sanitize_headers` by default

## Description

The plugin contains the logic that is necessary to replay any scenario that was recorded in the Chrome browser. It makes sense to use it by default. 

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Documentation / non-code

## Review

_List of tasks the reviewer must do to review the PR:_

- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes

None