### PR TITLE
bumping version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 -->
 
-## [0.1.0]
+## [1.0.0] - 2019-02-11
 
 ### Added
 
@@ -32,5 +32,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `transformer.plugins.Plugin` is renamed
   `transformer.plugins.contracts.OnTaskSequence`.
 
-[Unreleased]: https://github.com/zalando-incubator/transformer/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/zalando-incubator/transformer/compare/f842c4163e037dc345eaf1992187f58126b7d909...v0.1.0
+[Unreleased]: https://github.com/zalando-incubator/transformer/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/zalando-incubator/transformer/compare/f842c4163e037dc345eaf1992187f58126b7d909...v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "har-transformer"
-version = "0.1.0"
+version = "1.0.0"
 description = "A tool to convert HAR files into a locustfile."
 authors = [
     "Serhii Cherniavskyi <serhii.cherniavskyi@zalando.de>",


### PR DESCRIPTION
After #15, the "git tag" version is 0.1.1 (see the [Releases](https://github.com/zalando-incubator/Transformer/releases) page) and the PyPI version is still 0.1.0 (because the pyproject.toml needs to be updated with a new version before PyPI accepts a new archive).

This PR bumps the version to 1.0.0, as we are finally officially ready.

## Types of Changes

- Documentation / non-code

## Deployment Notes

Once this PR is merged, a tag should be created (on the merge commit) to represent the new version. This will create a GitHub release and trigger a Travis deployment to PyPI:

```
$ git tag -s v1.0.0 -m v1.0.0
$ git push --tags
```