### PR TITLE
New plugin sanitize headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an iterator over lines (as strings) instead of a string containing the full
   locustfile. This design allows for more flexibility in `dump`/`dumps` and
   should result in smaller memory usage for huge locustfiles. (#14)
+  - Preliminary support for new-generation plugins. (#25)
 
 ### Deprecated
 

--- a/images/transformer-design-internal-objects.svg
+++ b/images/transformer-design-internal-objects.svg
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 104.6994 25.954508"
+   height="25.954508mm"
+   width="104.6994mm">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="TriangleInM"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4666" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6051"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6049" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5827"
+       style="overflow:visible">
+      <path
+         id="path5825"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5775"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path5773" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5751"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path5749" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4675" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4551" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4533" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(2.4787255,-8.3305743)"
+     id="layer1">
+    <text
+       id="text3715"
+       y="13.914065"
+       x="6.0827303"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.26458332"
+         y="13.914065"
+         x="6.0827303"
+         id="tspan3713">HAR</tspan></text>
+    <text
+       id="text3719"
+       y="13.914065"
+       x="74.587692"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.26458332"
+         y="13.914065"
+         x="74.587692"
+         id="tspan3717">locustfile</tspan></text>
+    <path
+       id="path3723"
+       d="M 15.704437,12.517776 H 72.499212"
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79499996, 0.79499996;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#TriangleOutM)" />
+    <text
+       id="text4890"
+       y="11.010859"
+       x="34.428761"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';stroke-width:0.26458332"
+         y="11.010859"
+         x="34.428761"
+         id="tspan4888">Transformer</tspan></text>
+    <text
+       id="text5586"
+       y="29.141554"
+       x="47.184315"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         y="29.141554"
+         x="47.184315"
+         id="tspan5584">internal</tspan><tspan
+         id="tspan5588"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         y="33.551277"
+         x="47.184315">objects</tspan></text>
+    <path
+       id="path5590"
+       d="M 55.612982,29.788275 C 79.909075,27.645702 83.7391,16.379436 83.7391,16.379436"
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5775)" />
+    <path
+       id="path5590-8"
+       d="m 10.774522,16.379436 c 0,0 2.940518,11.715569 27.306349,13.840862"
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5827)" />
+    <path
+       id="path5979"
+       d="M -2.4787255,20.494099 H 102.22068"
+       style="fill:none;stroke:#8d8d8d;stroke-width:0.36500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.46, 1.46;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       id="path5983"
+       d="m 38.531691,53.359141 c 0,0 -9.287245,8.995834 8.551712,8.995833 17.838957,-10e-7 8.551711,-8.995833 8.551711,-8.995833"
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM)" />
+  </g>
+</svg>

--- a/images/transformer-design-plugins.svg
+++ b/images/transformer-design-plugins.svg
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 104.6994 38.122101"
+   height="38.122101mm"
+   width="104.6994mm">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="TriangleInM"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4666" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6051"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6049" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5827"
+       style="overflow:visible">
+      <path
+         id="path5825"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5775"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path5773" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5751"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path5749" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4675" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4551" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4533" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(2.4787255,-8.3305743)"
+     id="layer1">
+    <text
+       id="text3715"
+       y="13.914065"
+       x="6.0827303"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.26458332"
+         y="13.914065"
+         x="6.0827303"
+         id="tspan3713">HAR</tspan></text>
+    <text
+       id="text3719"
+       y="13.914065"
+       x="74.587692"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.26458332"
+         y="13.914065"
+         x="74.587692"
+         id="tspan3717">locustfile</tspan></text>
+    <path
+       id="path3723"
+       d="M 15.704437,12.517776 H 72.499212"
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.79499996, 0.79499996;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#TriangleOutM)" />
+    <text
+       id="text4890"
+       y="11.010859"
+       x="34.428761"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';stroke-width:0.26458332"
+         y="11.010859"
+         x="34.428761"
+         id="tspan4888">Transformer</tspan></text>
+    <text
+       id="text5586"
+       y="29.141554"
+       x="47.184315"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         y="29.141554"
+         x="47.184315"
+         id="tspan5584">internal</tspan><tspan
+         id="tspan5588"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         y="33.551277"
+         x="47.184315">objects</tspan></text>
+    <path
+       id="path5590"
+       d="M 55.612982,29.788275 C 79.909075,27.645702 83.7391,16.379436 83.7391,16.379436"
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5775)" />
+    <path
+       id="path5590-8"
+       d="m 10.774522,16.379436 c 0,0 2.940518,11.715569 27.306349,13.840862"
+       style="fill:none;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5827)" />
+    <path
+       id="path5979"
+       d="M -2.4787255,20.494099 H 102.22068"
+       style="fill:none;stroke:#8d8d8d;stroke-width:0.36500001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1.46, 1.46;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       id="path5983"
+       d="m 38.531691,33.250795 c 0,0 -9.287245,8.995834 8.551712,8.995833 17.838957,-1e-6 8.551711,-8.995833 8.551711,-8.995833"
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM)" />
+    <text
+       id="text6630"
+       y="45.718868"
+       x="40.534962"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';stroke-width:0.26458332"
+         y="45.718868"
+         x="40.534962"
+         id="tspan6628">plugins</tspan></text>
+  </g>
+</svg>

--- a/images/transformer-design-simple.svg
+++ b/images/transformer-design-simple.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 55.742924 5.6434355"
+   height="5.6434355mm"
+   width="55.742924mm">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4675" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4551" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path4533" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-6.4982088,-8.3305743)"
+     id="layer1">
+    <text
+       id="text3715"
+       y="13.914065"
+       x="6.0827303"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.26458332"
+         y="13.914065"
+         x="6.0827303"
+         id="tspan3713">HAR</tspan></text>
+    <text
+       id="text3719"
+       y="13.914065"
+       x="43.366833"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.26458332"
+         y="13.914065"
+         x="43.366833"
+         id="tspan3717">locustfile</tspan></text>
+    <path
+       id="path3723"
+       d="M 15.704437,12.517776 H 41.629582"
+       style="fill:none;stroke:#000000;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM)" />
+    <text
+       id="text4890"
+       y="11.010859"
+       x="18.024578"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52777767px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';stroke-width:0.26458332"
+         y="11.010859"
+         x="18.024578"
+         id="tspan4888">Transformer</tspan></text>
+  </g>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers=[
 packages = [{ include = "transformer" }]
 
 [tool.poetry.scripts]
-transformer = "transformer:cli.script_entrypoint"
+transformer = "transformer.cli:script_entrypoint"
 
 [tool.poetry.dependencies]
 python = "^3.6"

--- a/transformer/plugins/__init__.py
+++ b/transformer/plugins/__init__.py
@@ -1,3 +1,4 @@
 from .resolve import resolve
+from .contracts import plugin, Contract, apply, group_by_contract
 
-__all__ = ["resolve"]
+__all__ = ["resolve", "plugin", "Contract", "apply", "group_by_contract"]

--- a/transformer/plugins/contracts.py
+++ b/transformer/plugins/contracts.py
@@ -173,6 +173,6 @@ def group_by_contract(plugins: Iterable[Plugin]) -> DefaultDict[Contract, List[P
     for p in plugins:
         c = contract(p)
         for bc in _BASE_CONTRACTS:
-            if c & bc:
+            if c & bc:  # Contract is an enum.Flag: & computes the intersection.
                 res[bc].append(p)
     return res

--- a/transformer/plugins/contracts.py
+++ b/transformer/plugins/contracts.py
@@ -116,9 +116,10 @@ def plugin(c: Contract) -> Callable[[callable], callable]:
     :raise InvalidContractError: if c is not a valid contract.
     """
     if not isinstance(c, Contract):
+        suggestions = (f"@plugin(Contract.{x.name})" for x in Contract)
         raise InvalidContractError(
             f"{c!r} is not a {Contract.__qualname__}. "
-            "Did you mean e.g. @plugin(Contract.OnTask)?"
+            f"Did you mean {', '.join(suggestions)}?"
         )
 
     def _decorate(f: callable) -> callable:

--- a/transformer/plugins/dummy.py
+++ b/transformer/plugins/dummy.py
@@ -1,9 +1,20 @@
 import logging
-from typing import Sequence
+from typing import cast
 
+from transformer.plugins import plugin, Contract
+from transformer.request import Request
+from transformer.scenario import Scenario
 from transformer.task import Task
 
 
-def plugin(tasks: Sequence[Task]) -> Sequence[Task]:
-    logging.info(f"The first request was {tasks[0].request.url.geturl()}")
-    return tasks
+@plugin(Contract.OnScenario)
+def f(s: Scenario) -> Scenario:
+    first_req = first(s)
+    logging.info(f"The first request was {first_req.url.geturl()}")
+    return s
+
+
+def first(s: Scenario) -> Request:
+    while isinstance(s, Scenario):
+        s = s.children[0]
+    return cast(Task, s).request

--- a/transformer/plugins/resolve.py
+++ b/transformer/plugins/resolve.py
@@ -4,8 +4,13 @@ import logging
 from types import ModuleType
 from typing import Iterator
 
-from transformer.plugins import contracts
-from transformer.plugins.contracts import Plugin
+from transformer.plugins.contracts import (
+    Plugin,
+    Contract,
+    InvalidContractError,
+    contract,
+    InvalidPluginError,
+)
 
 
 def resolve(name: str) -> Iterator[Plugin]:
@@ -13,37 +18,55 @@ def resolve(name: str) -> Iterator[Plugin]:
     Transform a plugin name into the corresponding, actual plugins.
 
     The name of a plugin is the name of a Python module containing (at least)
-    one function which name begins with "plugin" and which is annotated
-    according to one of the "plugin contracts" (defined in the contracts module).
+    one function decorated with @plugin (from the contracts module).
     The "resolve" function loads that module and returns these plugin functions
     found inside the module.
+
+    :raise ImportError: if name does not match an accessible module.
+    :raise TypeError: from load_load_plugins_from_module.
+    :raise InvalidContractError: from load_load_plugins_from_module.
+    :raise NoPluginError: from load_load_plugins_from_module.
     """
-    try:
-        module = importlib.import_module(name)
-    except ImportError as err:
-        logging.error(f"failed to import plugin module {name!r}: {err}")
-        return iter(())
+    module = importlib.import_module(name)
 
-    return load_plugins_from_module(module)
+    yield from load_plugins_from_module(module)
 
 
-PLUGIN_PREFIX = "plugin"
+class NoPluginError(ValueError):
+    """
+    Raised for Python modules that should but don't contain any plugin function.
+    """
 
 
 def load_plugins_from_module(module: ModuleType) -> Iterator[Plugin]:
+    """
+    :param module: Python module from which to load plugin functions.
+    :raise TypeError: if module is not a Python module.
+    :raise InvalidContractError: if a function is associated to an invalid contract.
+    :raise NoPluginError: if module doesn't contain at least one plugin function.
+    """
     if not inspect.ismodule(module):
         raise TypeError(f"expected a module, got {module!r}")
-    at_least_once = False
-    for obj_name, obj in inspect.getmembers(module, inspect.isfunction):
-        if obj_name.startswith(PLUGIN_PREFIX):
-            valid = contracts.isvalid(Plugin, obj)
-            if not valid:
-                logging.warning(f"ignoring {obj_name}: {valid.reason}")
-            else:
-                at_least_once = True
-                yield obj
-        else:
-            logging.debug(f"ignoring {obj_name}: doesn't start with {PLUGIN_PREFIX!r}")
 
-    if not at_least_once:
-        logging.error(f"module {module} doesn't contain plugin functions")
+    nb_plugins = 0
+
+    for _, obj in inspect.getmembers(module, inspect.isfunction):
+        try:
+            c = contract(obj)
+        except InvalidPluginError:
+            logging.debug(f"ignoring {_n(obj)}: not decorated with @plugin")
+            continue
+
+        if not isinstance(c, Contract):
+            msg = f"{_n(obj)} associated to an invalid contract {c!r}"
+            raise InvalidContractError(msg)
+
+        nb_plugins += 1
+        yield obj
+
+    if nb_plugins < 1:
+        raise NoPluginError(module)
+
+
+def _n(x) -> str:
+    return getattr(x, "__qualname__", None) or repr(x)

--- a/transformer/plugins/sanitize_headers.md
+++ b/transformer/plugins/sanitize_headers.md
@@ -1,11 +1,12 @@
 # Sanitizing headers
 
-The [`sanitize_headers` plugin](sanitize_headers.py) should be used for processing scenarios that were generated 
-in the Chrome browser, but is advised to be used whenever cookies handling is important.
- 
-The plugin removes Chrome-specific, RFC non-compliant headers starting with ":". 
+The [`sanitize_headers` plugin](sanitize_headers.py) should be used for
+processing scenarios generated in the Chrome browser, but is also advised to
+use it whenever cookies handling is important.
 
-Example of such headers:
+The plugin removes Chrome-specific, RFC-non-compliant headers starting with `:`.
+
+Examples of such headers:
 ```
 :authority: chrome.google.com
 :method: POST
@@ -13,8 +14,9 @@ Example of such headers:
 :scheme: https
 ```
 
-Additionally the plugin:
-- maps header keys to lowercase, which makes further overriding of headers deterministic,
-- ignores the `cookie` header, as cookies are handled by [Locust's `HttpSession`][http-session].
+Additionally, the plugin:
+  - converts header names to lowercase, which simplifies further header overriding,
+  - ignores the `cookie` header, as cookies are handled by
+  [Locust's _HttpSession_][http-session].
 
 [http-session]: https://docs.locust.io/en/stable/api.html#httpsession-class

--- a/transformer/plugins/sanitize_headers.py
+++ b/transformer/plugins/sanitize_headers.py
@@ -1,38 +1,24 @@
-from typing import Sequence
-
-from transformer.task import Task, LocustRequest
 from transformer.helpers import zip_kv_pairs
+from transformer.task import Task2
 
 
-def plugin(tasks: Sequence[Task]) -> Sequence[Task]:
+def plugin(task: Task2) -> Task2:
     """
-    Removes Chrome-specific, RFC non-compliant headers starting with ":".
-    Maps header keys to lowercase to make overriding deterministic.
-    Removes cookie header as it is handled by Locust's HttpSession.
+    Removes Chrome-specific, RFC-non-compliant headers starting with `:`.
+    Converts header names to lowercase to simplify further overriding.
+    Removes the cookie header as it is handled by Locust's HttpSession.
     """
-    modified_tasks = []
-    for task in tasks:
+    headers = task.request.headers
 
-        if task.locust_request is None:
-            task = task._replace(
-                locust_request=LocustRequest.from_request(task.request)
-            )
+    if not isinstance(headers, dict):
+        headers = zip_kv_pairs(headers)
 
-        headers = task.locust_request.headers
+    sanitized_headers = {
+        k.lower(): v
+        for (k, v) in headers.items()
+        if not k.startswith(":") and k.lower() != "cookie"
+    }
 
-        if not isinstance(headers, dict):
-            headers = zip_kv_pairs(headers)
+    task.request = task.request._replace(headers=sanitized_headers)
 
-        sanitized_headers = {
-            k.lower(): v
-            for (k, v) in headers.items()
-            if not k.startswith(":") and k.lower() != "cookie"
-        }
-
-        task = task._replace(
-            locust_request=task.locust_request._replace(headers=sanitized_headers)
-        )
-
-        modified_tasks.append(task)
-
-    return modified_tasks
+    return task

--- a/transformer/plugins/sanitize_headers.py
+++ b/transformer/plugins/sanitize_headers.py
@@ -1,7 +1,9 @@
 from transformer.helpers import zip_kv_pairs
+from transformer.plugins import plugin, Contract
 from transformer.task import Task2
 
 
+@plugin(Contract.OnTask)
 def plugin(task: Task2) -> Task2:
     """
     Removes Chrome-specific, RFC-non-compliant headers starting with `:`.

--- a/transformer/plugins/test_contracts.py
+++ b/transformer/plugins/test_contracts.py
@@ -1,55 +1,122 @@
-from typing import Callable
-from unittest.mock import MagicMock
-
 import pytest
+from hypothesis import given
+from hypothesis.strategies import from_type
 
-from transformer.task import Task2
-from .contracts import isvalid, Plugin, OnTask
+from transformer.plugins import apply, group_by_contract
+from .contracts import (
+    Contract,
+    plugin,
+    contract,
+    InvalidContractError,
+    InvalidPluginError,
+)
 
 
-class TestIsvalid:
-    def test_no_if_obj_is_not_a_function_regardless_of_plugin(self):
-        class A:
-            pass
+@given(from_type(Contract))
+def test_contract_returns_contract_associated_with_plugin_decorator(c: Contract):
+    @plugin(c)
+    def foo():
+        ...
 
-        assert not isvalid(MagicMock(), A())
-        assert not isvalid(MagicMock(), 2)
-        assert not isvalid(MagicMock(), "x")
+    assert contract(foo) is c
 
-    def test_raises_error_for_unknown_plugin(self):
-        def f(_: int) -> int:
+
+def test_plugin_decorator_raises_with_invalid_contract():
+    with pytest.raises(InvalidContractError):
+
+        @plugin(2)
+        def foo():
             ...
 
-        IntPlugin = Callable[[int], int]
-        with pytest.raises(TypeError):
-            isvalid(IntPlugin, f)
 
-    def test_no_if_obj_has_no_signature(self):
-        def f(task):
-            return task
+def test_plugin_decorator_raises_without_contract():
+    with pytest.raises(InvalidContractError):
 
-        assert not isvalid(OnTask, f)
+        @plugin
+        def foo():
+            ...
 
-    def test_no_if_obj_has_wrong_signature(self):
-        def f(b: bool) -> bool:
-            return b
 
-        assert not isvalid(OnTask, f)
+def test_contract_raises_with_invalid_plugin():
+    def foo():
+        ...
 
-    def test_yes_if_obj_has_right_signature(self):
-        def f(t: Task2) -> Task2:
-            return t
+    with pytest.raises(InvalidPluginError):
+        contract(foo)
 
-        assert isvalid(OnTask, f)
 
-    def test_isvalid_plugin_false_if_false_for_all_plugin_subtypes(self):
-        def f(t: bool) -> bool:
-            return t
+def test_plugin_is_exported_by_the_transformer_plugins_module():
+    try:
+        from transformer.plugins import plugin
+    except ImportError:
+        pytest.fail("plugin should be exported by transformer.plugins")
 
-        assert not isvalid(Plugin, f)
 
-    def test_isvalid_plugin_true_if_true_for_a_plugin_subtype(self):
-        def f(t: Task2) -> Task2:
-            return t
+def test_Contract_is_exported_by_the_transformer_plugins_module():
+    try:
+        from transformer.plugins import Contract
+    except ImportError:
+        pytest.fail("Contract should be exported by transformer.plugins")
 
-        assert isvalid(Plugin, f)
+
+class TestApply:
+    def test_return_init_unchanged_without_plugins(self):
+        x = object()
+        assert apply([], x) is x
+
+    def test_return_plugin_result(self):
+        @plugin(Contract.OnTask)
+        def plugin_a(x: str) -> str:
+            return x + "a"
+
+        assert apply([plugin_a], "z") == "za"
+
+    def test_runs_plugins_in_succession_on_input(self):
+        @plugin(Contract.OnTask)
+        def plugin_a(x: str) -> str:
+            return x + "a"
+
+        @plugin(Contract.OnTask)
+        def plugin_b(x: str) -> str:
+            return x + "b"
+
+        assert apply((plugin_a, plugin_b), "") == "ab"
+        assert apply((plugin_b, plugin_a, plugin_b), "") == "bab"
+
+
+class TestGroupByContract:
+    def test_return_empty_dict_when_no_plugins(self):
+        assert group_by_contract([]) == {}
+
+    def test_index_plugins_with_simple_contracts_by_their_contract(self):
+        @plugin(Contract.OnTask)
+        def plugin_a():
+            pass
+
+        @plugin(Contract.OnTask)
+        def plugin_b():
+            pass
+
+        @plugin(Contract.OnScenario)
+        def plugin_z():
+            pass
+
+        assert group_by_contract((plugin_a, plugin_b, plugin_z)) == {
+            Contract.OnScenario: [plugin_z],
+            Contract.OnTask: [plugin_a, plugin_b],
+        }
+
+    def test_index_plugins_with_complex_contracts_by_their_basic_contracts(self):
+        @plugin(Contract.OnTask)
+        def plugin_task():
+            pass
+
+        @plugin(Contract.OnTask | Contract.OnScenario | Contract.OnPythonProgram)
+        def plugin_multi():
+            pass
+
+        assert group_by_contract((plugin_task, plugin_multi)) == {
+            Contract.OnTask: [plugin_task, plugin_multi],
+            Contract.OnScenario: [plugin_multi],
+            Contract.OnPythonProgram: [plugin_multi],
+        }

--- a/transformer/plugins/test_dummy.py
+++ b/transformer/plugins/test_dummy.py
@@ -1,18 +1,18 @@
 import logging
+import os
 from pathlib import Path
 
+import transformer
 from transformer.helpers import DUMMY_HAR_STRING
-from transformer.scenario import Scenario
 
 
 def test_dummy_plugin_works(tmp_path: Path, caplog):
-    from transformer.plugins import dummy
-
     har_path = tmp_path / "test.har"
     har_path.write_text(DUMMY_HAR_STRING)
 
     caplog.set_level(logging.INFO)
 
-    Scenario.from_path(har_path, plugins=[dummy.plugin])
+    with open(os.path.devnull, "w") as f:
+        transformer.dump(f, [har_path], plugins=["transformer.plugins.dummy"])
 
-    assert "https://www.zalando.de" in caplog.text
+    assert "The first request was https://www.zalando.de" in caplog.text

--- a/transformer/plugins/test_sanitize_headers.py
+++ b/transformer/plugins/test_sanitize_headers.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 from datetime import datetime
 from urllib.parse import urlparse
 

--- a/transformer/test_locust.py
+++ b/transformer/test_locust.py
@@ -52,42 +52,6 @@ class LocustForScenarioGroup(HttpLocust):
         assert expected.strip() == script.strip()
 
 
-def test_generates_passed_global_code_blocks():
-    sg1 = Scenario(
-        "sg1",
-        children=[
-            MagicMock(
-                spec_set=Scenario, children=[], global_code_blocks={"b1": ["ab"]}
-            ),
-            MagicMock(
-                spec_set=Scenario, children=[], global_code_blocks={"b2": ["cd"]}
-            ),
-        ],
-        origin=None,
-    )
-    sg2 = Scenario(
-        "sg2",
-        children=[MagicMock(spec_set=Scenario, children=[], global_code_blocks={})],
-        origin=None,
-    )
-    sg3 = Scenario(
-        "sg3",
-        children=[
-            MagicMock(
-                spec_set=Scenario,
-                children=[],
-                global_code_blocks={"b3": ["yz"], "b2": ["yyy", "zzz"]},
-            )
-        ],
-        origin=None,
-    )
-
-    code = locustfile([sg1, sg2, sg3])
-    assert code.endswith(
-        "\n# b1\nab\n# b2\nyyy\nzzz\n# b3\nyz"
-    ), "the latter b2 block should override the former"
-
-
 def test_locust_taskset_raises_on_malformed_scenario():
     bad_child = cast(Scenario, 7)
     bad_scenario = Scenario(name="x", children=[bad_child], origin=None)

--- a/transformer/test_locust.py
+++ b/transformer/test_locust.py
@@ -52,6 +52,42 @@ class LocustForScenarioGroup(HttpLocust):
         assert expected.strip() == script.strip()
 
 
+def test_generates_passed_global_code_blocks():
+    sg1 = Scenario(
+        "sg1",
+        children=[
+            MagicMock(
+                spec_set=Scenario, children=[], global_code_blocks={"b1": ["ab"]}
+            ),
+            MagicMock(
+                spec_set=Scenario, children=[], global_code_blocks={"b2": ["cd"]}
+            ),
+        ],
+        origin=None,
+    )
+    sg2 = Scenario(
+        "sg2",
+        children=[MagicMock(spec_set=Scenario, children=[], global_code_blocks={})],
+        origin=None,
+    )
+    sg3 = Scenario(
+        "sg3",
+        children=[
+            MagicMock(
+                spec_set=Scenario,
+                children=[],
+                global_code_blocks={"b3": ["yz"], "b2": ["yyy", "zzz"]},
+            )
+        ],
+        origin=None,
+    )
+
+    code = locustfile([sg1, sg2, sg3])
+    assert code.endswith(
+        "\n# b1\nab\n# b2\nyyy\nzzz\n# b3\nyz"
+    ), "the latter b2 block should override the former"
+
+
 def test_locust_taskset_raises_on_malformed_scenario():
     bad_child = cast(Scenario, 7)
     bad_scenario = Scenario(name="x", children=[bad_child], origin=None)


### PR DESCRIPTION
This is the next step in #11: converting the _Sanitize Headers_ plugin from the old plugin architecture (with sequences of tasks as input/output) to the new one (with, in this particular case, a task as input/output).

## Description

- Added hooks for the `OnTask`, `OnTaskSequence`, `OnScenario`, and `OnPythonProgram` contracts in Transformer, so that the corresponding plugins receive their expected inputs.
- Simplified implementation of "plugin contracts": instead of relying on function signatures (which requires sophisticated algorithms to deal with subtyping and the yet unstable `typing` API), use a basic decorator that annotates the plugin function with a private field. Contracts become elements of a `Contract` enum instead of being `typing.Callable` specs.
- (minor) Improve error reporting when `transformer` is used from the CLI.

The new documentation about writing plugins is [in the wiki](https://github.com/zalando-incubator/Transformer/wiki/Writing-plugins).

## Types of Changes

- Refactor/improvements
- Documentation / non-code

## Tasks

_List of tasks you will do to complete the PR:_

- [x] What is described above.
- [x] Update the changelog.
- [ ] Add functional tests. We can no longer rely on unit tests with so many moving parts.