### PR TITLE
Fix Read The Docs integration

### DIFF
--- a/docs/Versioning.rst
+++ b/docs/Versioning.rst
@@ -45,7 +45,7 @@ In doubt, please refer to SemVer_, which is the source of these guidelines.
 Update pyproject.toml
 '''''''''''''''''''''
 
-In :file:`pyproject.toml`, update the ``version`` value to ``vX.Y.Z``.
+In :file:`pyproject.toml`, update the ``version`` value to ``X.Y.Z``.
 
 .. code-block:: diff
 

--- a/docs/Versioning.rst
+++ b/docs/Versioning.rst
@@ -12,6 +12,9 @@ unlikely to be fixed if they don't exist in the most recent release.
 
 For all available releases, see the `releases page`_.
 
+.. contents::
+   :local:
+
 .. _releases page: https://github.com/zalando-incubator/Transformer/releases
 
 Release process
@@ -38,6 +41,32 @@ The identifier of the new release must follow the :samp:`v{X}.{Y}.{Z}` format
 - Otherwise, when you make **backwards-compatible bug fixes**, **increment Z**.
 
 In doubt, please refer to SemVer_, which is the source of these guidelines.
+
+Update pyproject.toml
+'''''''''''''''''''''
+
+In :file:`pyproject.toml`, update the ``version`` value to ``vX.Y.Z``.
+
+.. code-block:: diff
+
+     [tool.poetry]
+     name = "har-transformer"
+   - version = "A.B.C"
+   + version = "X.Y.Z"
+
+Update the Sphinx config
+''''''''''''''''''''''''
+
+In :file:`docs/conf.py`, update the ``version`` and ``release`` values:
+
+.. code-block:: diff
+
+     # The short X.Y version
+   - version = "A.B"
+   + version = "X.Y"
+     # The full version, including alpha/beta/rc tags
+   - release = "A.B.C"
+   + release = "X.Y.Z"
 
 Update the changelog
 ''''''''''''''''''''

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,21 +16,16 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import transformer
-import packaging.version
-
 # -- Project information -----------------------------------------------------
 
 project = "Transformer"
 copyright = "2019, Zalando"
 author = "the Zalando maintainers"
 
-_version = packaging.version.parse(transformer.__version__)
-
 # The short X.Y version
-version = ".".join(str(x) for x in _version.release[:2])
+version = "1.0"
 # The full version, including alpha/beta/rc tags
-release = transformer.__version__
+release = "1.0.2"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
After #38, the documentation cannot be automatically built by Read The Docs because it depends on the `transformer` module (for reading the version number), which is not built by Read The Docs.

Removing dependency on `transformer` and documenting what needs to be done manually when releasing instead.

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change
- Documentation / non-code