### PR TITLE
Updates the repository type to tools

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,2 +1,2 @@
 X-Zalando-Team: tip
-X-Zalando-Type: code
+X-Zalando-Type: tools


### PR DESCRIPTION
# Update repository type
To be compliant and use Zincr, the repository must be setup to be a tools repo and cannot be deployed via CDP internally.

> Issue : #1234 (only if appropriate)

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change