### PR TITLE
Expose all HAR "entry" fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
 - '3.6'
 - '3.7'
 install:
+# workaround for backward compatibility to Poetry: https://github.com/sdispater/poetry/issues/1049
+- pip install --upgrade pip==18.1
 - pip install poetry codacy-coverage
 - poetry install
 script:

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,6 +15,25 @@ The format is based on `Keep a Changelog`_, and this project adheres to
    :local:
    :depth: 1
 
+.. _v1.1.2:
+
+v1.1.2
+======
+
+- Release date: 2019-04-25 14:49
+
+- Diff__.
+
+__ https://github.com/zalando-incubator/transformer/compare/v1.1.1...v1.1.2
+
+Added
+-----
+
+:attr:`transformer.request.Request.har_entry`
+   This new read-only property contains the entry as recorded in a HAR file,
+   corresponding to the specific :class:`Request <transformer.request.Request>` object.
+   As requested by :user:`xinke2411` (:issue:`35`)
+
 .. _v1.1.1:
 
 v1.1.1

--- a/docs/Writing-plugins.rst
+++ b/docs/Writing-plugins.rst
@@ -67,6 +67,14 @@ that make requests to a specific URL.
 It would not need to modify :term:`scenario` objects or the :term:`syntax tree`
 directly.
 
+.. warning::
+
+   Modifying :any:`har_entry <transformer.request.Request.har_entry>` property
+   of a :class:`Request <transformer.request.Request>` object will not have any effect on the resulting
+   :term:`task`. The field serves the purpose of exposing all data recorded in a HAR file corresponding
+   to the specific :class:`Request <transformer.request.Request>`, that might have otherwise not been reflected
+   in the intermediate representation.
+
 To let Transformer know that this authentication plugin must be executed with
 :term:`task` objects passed as input (and not, say, :term:`scenario` objects),
 the plugin's author must announce that **the plugin satisfies a specific

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ author = "the Zalando maintainers"
 # The short X.Y version
 version = "1.1"
 # The full version, including alpha/beta/rc tags
-release = "1.1.1"
+release = "1.1.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "har-transformer"
-version = "1.1.1"
+version = "1.1.2"
 description = "A tool to convert HAR files into a locustfile."
 authors = [
     "Serhii Cherniavskyi <serhii.cherniavskyi@zalando.de>",

--- a/transformer/plugins/test_sanitize_headers.py
+++ b/transformer/plugins/test_sanitize_headers.py
@@ -22,6 +22,7 @@ def task_with_header(name: str, value: str) -> Task2:
             timestamp=TS,
             method=HttpMethod.GET,
             url=urlparse("https://example.com"),
+            har_entry={"entry": "data"},
             name="task_name",
             headers=[Header(name=name, value=value)],
             post_data={},

--- a/transformer/request.py
+++ b/transformer/request.py
@@ -67,18 +67,24 @@ class Request:
 
     .. attribute:: timestamp
 
-       :class:`~datetime.datetime` --
-       Time at which the request was recorded.
+        :class:`~datetime.datetime` --
+        Time at which the request was recorded.
 
     .. attribute:: method
 
-       :class:`HttpMethod` --
-       HTTP method of the request.
+        :class:`HttpMethod` --
+        HTTP method of the request.
 
     .. attribute:: url
 
-       :class:`urllib.parse.SplitResult` --
-       URL targeted by the request.
+        :class:`urllib.parse.SplitResult` --
+        URL targeted by the request.
+
+    .. attribute:: har_entry
+
+        :any:`dict` --
+        A single record from entries as recorded in a HAR file (http://www.softwareishard.com/blog/har-12-spec/#entries)
+        corresponding to the request, provided for read-only access.
 
     .. attribute:: headers
        :annotation: = []

--- a/transformer/request.py
+++ b/transformer/request.py
@@ -115,6 +115,7 @@ class Request:
     timestamp: datetime
     method: HttpMethod
     url: SplitResult
+    har_entry: dict
     headers: List[Header] = ()
     post_data: Optional[dict] = None
     query: List[QueryPair] = ()
@@ -141,6 +142,7 @@ class Request:
             timestamp=pendulum.parse(entry["startedDateTime"]),
             method=HttpMethod[request["method"]],
             url=urlparse(request["url"]),
+            har_entry=entry,
             name=None,
             headers=[
                 Header(name=d["name"], value=d["value"])

--- a/transformer/request.py
+++ b/transformer/request.py
@@ -83,7 +83,8 @@ class Request:
     .. attribute:: har_entry
 
         :any:`dict` --
-        A single record from entries as recorded in a HAR file (http://www.softwareishard.com/blog/har-12-spec/#entries)
+        A single record from entries as recorded in a HAR file
+        (http://www.softwareishard.com/blog/har-12-spec/#entries)
         corresponding to the request, provided for read-only access.
 
     .. attribute:: headers

--- a/transformer/test_request.py
+++ b/transformer/test_request.py
@@ -84,6 +84,33 @@ class TestFromHarEntry:
         assert request.method == HttpMethod.DELETE
         assert request.query == [QueryPair(name="some name", value="some value")]
 
+    def test_it_records_har_entry(self):
+        entry = {
+            "request": {
+                "method": "GET",
+                "url": "localhost"
+            },
+            "response": {
+                "status": 200,
+                "statusText": "OK",
+            },
+            "cache": {},
+            "timings": {
+              "connect": 22,
+              "wait": 46,
+              "receive": 0
+            },
+            "startedDateTime": "2018-01-01",
+            "time": 116,
+            "_securityState": "secure",
+            "connection": "443"
+        }
+        request = Request.from_har_entry(entry)
+        assert isinstance(request, Request)
+        assert request.har_entry
+        assert str(request.url.geturl()) == request.har_entry["request"]["url"]
+        assert request.har_entry["_securityState"] == "secure"
+
 
 class TestAllFromHar:
     @pytest.mark.skip(reason="Doesn't raise AssertionError; to be investigated.")

--- a/transformer/test_task.py
+++ b/transformer/test_task.py
@@ -219,6 +219,7 @@ class TestReqToExpr:
             timestamp=MagicMock(),
             method=HttpMethod.GET,
             url=urlparse(url),
+            har_entry={"entry": "data"},
             headers=[Header("a", "b")],
             query=[QueryPair("x", "y")],  # query is currently ignored for GET
         )
@@ -239,6 +240,7 @@ class TestReqToExpr:
             timestamp=MagicMock(),
             method=HttpMethod.POST,
             url=urlparse(url),
+            har_entry={"entry": "data"},
             headers=[Header("a", "b")],
             post_data={
                 "mimeType": "application/x-www-form-urlencoded",
@@ -265,6 +267,7 @@ class TestReqToExpr:
             timestamp=MagicMock(),
             method=HttpMethod.POST,
             url=urlparse(url),
+            har_entry={"entry": "data"},
             headers=[Header("a", "b")],
             post_data={
                 "mimeType": "application/json",
@@ -291,6 +294,7 @@ class TestReqToExpr:
             timestamp=MagicMock(),
             method=HttpMethod.POST,
             url=urlparse(url),
+            har_entry={"entry": "data"},
             headers=[Header("a", "b")],
             post_data=None,
         )
@@ -311,6 +315,7 @@ class TestReqToExpr:
             timestamp=MagicMock(),
             method=HttpMethod.PUT,
             url=urlparse(url),
+            har_entry={"entry": "data"},
             headers=[Header("a", "b")],
             query=[QueryPair("c", "d")],
             post_data={
@@ -338,6 +343,7 @@ class TestReqToExpr:
             timestamp=MagicMock(),
             method=HttpMethod.PUT,
             url=urlparse(url),
+            har_entry={"entry": "data"},
             headers=[Header("a", "b")],
             query=[QueryPair("c", "d")],
             post_data=None,
@@ -358,7 +364,7 @@ class TestReqToExpr:
         url = "http://abc.de"
         name = "my-req"
         r = Request(
-            name=name, timestamp=MagicMock(), method=HttpMethod.GET, url=urlparse(url)
+            name=name, timestamp=MagicMock(), method=HttpMethod.GET, url=urlparse(url), har_entry={"entry": "data"}
         )
         assert req_to_expr(r) == py.FunctionCall(
             name="self.client.get",
@@ -379,6 +385,7 @@ class TestLreqToExpr:
                 timestamp=MagicMock(),
                 method=HttpMethod.GET,
                 url=urlparse(url),
+                har_entry={"entry": "data"},
                 headers=[Header("a", "b")],
                 query=[QueryPair("x", "y")],  # query is currently ignored for GET
             )
@@ -415,6 +422,7 @@ class TestLreqToExpr:
                 timestamp=MagicMock(),
                 method=HttpMethod.POST,
                 url=urlparse(url),
+                har_entry={"entry": "data"},
                 headers=[Header("a", "b")],
                 post_data={
                     "mimeType": "application/x-www-form-urlencoded",
@@ -443,6 +451,7 @@ class TestLreqToExpr:
                 timestamp=MagicMock(),
                 method=HttpMethod.POST,
                 url=urlparse(url),
+                har_entry={"entry": "data"},
                 headers=[Header("a", "b")],
                 post_data={
                     "mimeType": "application/json",
@@ -471,6 +480,7 @@ class TestLreqToExpr:
                 timestamp=MagicMock(),
                 method=HttpMethod.POST,
                 url=urlparse(url),
+                har_entry={"entry": "data"},
                 headers=[Header("a", "b")],
                 post_data=None,
             )
@@ -493,6 +503,7 @@ class TestLreqToExpr:
                 timestamp=MagicMock(),
                 method=HttpMethod.PUT,
                 url=urlparse(url),
+                har_entry={"entry": "data"},
                 headers=[Header("a", "b")],
                 query=[QueryPair("c", "d")],
                 post_data={
@@ -522,6 +533,7 @@ class TestLreqToExpr:
                 timestamp=MagicMock(),
                 method=HttpMethod.PUT,
                 url=urlparse(url),
+                har_entry={"entry": "data"},
                 headers=[Header("a", "b")],
                 query=[QueryPair("c", "d")],
                 post_data=None,
@@ -548,6 +560,7 @@ class TestLreqToExpr:
                 timestamp=MagicMock(),
                 method=HttpMethod.GET,
                 url=urlparse(url),
+                har_entry={"entry": "data"}
             )
         )
         assert lreq_to_expr(r) == py.FunctionCall(


### PR DESCRIPTION
Expose all HAR "entry" fields.

Closes #35 

## Description

Added a new property in the `Request` class to expose all the information about a single entry that was recorded in the HAR file, and that used to be ignored in our intermediate representation.

## Types of Changes

- New feature (non-breaking change which adds functionality)
- Documentation / non-code

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.

