### PR TITLE
Read the blacklist once

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,6 +15,23 @@ The format is based on `Keep a Changelog`_, and this project adheres to
    :local:
    :depth: 1
 
+.. _v1.1.3:
+
+v1.1.3
+======
+
+- Release date: 2019-04-26 16:44
+
+- Diff__.
+
+__ https://github.com/zalando-incubator/transformer/compare/v1.1.2...v1.1.3
+
+Changed
+-------
+
+Blacklisting mechanism now opens the `.urlignore` file once per execution of the program,
+instead of once per :class:`Request <transformer.request.Request>`.
+
 .. _v1.1.2:
 
 v1.1.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ author = "the Zalando maintainers"
 # The short X.Y version
 version = "1.1"
 # The full version, including alpha/beta/rc tags
-release = "1.1.2"
+release = "1.1.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "har-transformer"
-version = "1.1.2"
+version = "1.1.3"
 description = "A tool to convert HAR files into a locustfile."
 authors = [
     "Serhii Cherniavskyi <serhii.cherniavskyi@zalando.de>",

--- a/transformer/blacklist.py
+++ b/transformer/blacklist.py
@@ -5,6 +5,10 @@ from typing import Set
 Blacklist = Set[str]
 
 
+def get_empty() -> Blacklist:
+    return set()
+
+
 def from_file() -> Blacklist:
     blacklist_file = f"{os.getcwd()}/.urlignore"
     try:
@@ -14,7 +18,7 @@ def from_file() -> Blacklist:
         logging.debug(
             "Could not read blacklist file %s. Reason: %s", blacklist_file, err
         )
-        return set()
+        return get_empty()
 
 
 def on_blacklist(blacklist: Blacklist, url: str) -> bool:

--- a/transformer/blacklist.py
+++ b/transformer/blacklist.py
@@ -1,19 +1,20 @@
-import os
 import logging
-from typing import Sequence
+import os
+from typing import Set
 
-Blacklist = Sequence[str]
+Blacklist = Set[str]
 
 
 def from_file() -> Blacklist:
     blacklist_file = f"{os.getcwd()}/.urlignore"
     try:
         with open(blacklist_file) as file:
-            return [line.rstrip("\n") for line in file if len(line) > 1]
+            return set(filter(None, [line.rstrip() for line in file]))
     except OSError as err:
         logging.debug(
             "Could not read blacklist file %s. Reason: %s", blacklist_file, err
         )
+        return set()
 
 
 def on_blacklist(blacklist: Blacklist, url: str) -> bool:
@@ -21,8 +22,7 @@ def on_blacklist(blacklist: Blacklist, url: str) -> bool:
     Checks for matching URLs in an ignore file (blacklist)
     from user's current directory.
     """
-    if blacklist:
-        for blacklist_item in blacklist:
-            if blacklist_item in url:
-                return True
+    for blacklist_item in blacklist:
+        if blacklist_item in url:
+            return True
     return False

--- a/transformer/blacklist.py
+++ b/transformer/blacklist.py
@@ -1,25 +1,28 @@
 import os
 import logging
+from typing import Sequence
+
+Blacklist = Sequence[str]
 
 
-def on_blacklist(url):
-    """
-    Checks for matching URLs in an ignore file (blacklist)
-    from user's current directory.
-    """
+def from_file() -> Blacklist:
     blacklist_file = f"{os.getcwd()}/.urlignore"
     try:
         with open(blacklist_file) as file:
-            blacklist = [line.rstrip("\n") for line in file if len(line) > 1]
-
-        for blacklist_item in blacklist:
-            if blacklist_item in url:
-                return True
-
-        return False
-
+            return [line.rstrip("\n") for line in file if len(line) > 1]
     except OSError as err:
         logging.debug(
             "Could not read blacklist file %s. Reason: %s", blacklist_file, err
         )
-        return False
+
+
+def on_blacklist(blacklist: Blacklist, url: str) -> bool:
+    """
+    Checks for matching URLs in an ignore file (blacklist)
+    from user's current directory.
+    """
+    if blacklist:
+        for blacklist_item in blacklist:
+            if blacklist_item in url:
+                return True
+    return False

--- a/transformer/scenario.py
+++ b/transformer/scenario.py
@@ -124,7 +124,7 @@ class Scenario:
         plugins: Sequence[Plugin] = (),
         ts_plugins: Sequence[Plugin] = (),
         short_name: bool = False,
-        blacklist: Optional[Blacklist] = None,
+        blacklist: Blacklist = set(),
     ) -> "Scenario":
         """
         Makes a :class:`Scenario` (possibly containing sub-scenarios) out of
@@ -147,12 +147,12 @@ class Scenario:
             but *True* when generating sub-scenarios (:attr:`children`) from
             a directory *path* (because then the names are "scoped" by
             the parent directory).
-        :param blacklist: a sequence of urls to be blacklisted
+        :param blacklist: a set of urls to be blacklisted
         """
         if path.is_dir():
             return cls.from_dir(
                 path,
-                plugins,
+                plugins=plugins,
                 ts_plugins=ts_plugins,
                 short_name=short_name,
                 blacklist=blacklist,
@@ -173,7 +173,7 @@ class Scenario:
         plugins: Sequence[Plugin],
         ts_plugins: Sequence[Plugin],
         short_name: bool,
-        blacklist: Optional[Blacklist] = None,
+        blacklist: Blacklist,
     ) -> "Scenario":
         """
         Makes a :class:`Scenario` out of the provided directory *path*.
@@ -301,7 +301,7 @@ class Scenario:
         plugins: Sequence[Plugin],
         ts_plugins: Sequence[Plugin],
         short_name: bool,
-        blacklist: Optional[Blacklist] = None,
+        blacklist: Blacklist,
     ) -> "Scenario":
         """
         Creates a Scenario given a HAR file.

--- a/transformer/scenario.py
+++ b/transformer/scenario.py
@@ -28,7 +28,6 @@ import dataclasses
 from dataclasses import dataclass
 
 import transformer.plugins as plug
-from transformer import blacklist
 from transformer.blacklist import Blacklist
 from transformer.naming import to_identifier
 from transformer.plugins.contracts import Plugin

--- a/transformer/scenario.py
+++ b/transformer/scenario.py
@@ -125,7 +125,7 @@ class Scenario:
         plugins: Sequence[Plugin] = (),
         ts_plugins: Sequence[Plugin] = (),
         short_name: bool = False,
-        blacklist: Optional[Blacklist] = None
+        blacklist: Optional[Blacklist] = None,
     ) -> "Scenario":
         """
         Makes a :class:`Scenario` (possibly containing sub-scenarios) out of
@@ -152,11 +152,19 @@ class Scenario:
         """
         if path.is_dir():
             return cls.from_dir(
-                path, plugins, ts_plugins=ts_plugins, short_name=short_name, blacklist=blacklist
+                path,
+                plugins,
+                ts_plugins=ts_plugins,
+                short_name=short_name,
+                blacklist=blacklist,
             )
         else:
             return cls.from_har_file(
-                path, plugins, ts_plugins=ts_plugins, short_name=short_name, blacklist=blacklist
+                path,
+                plugins,
+                ts_plugins=ts_plugins,
+                short_name=short_name,
+                blacklist=blacklist,
             )
 
     @classmethod
@@ -166,7 +174,7 @@ class Scenario:
         plugins: Sequence[Plugin],
         ts_plugins: Sequence[Plugin],
         short_name: bool,
-        blacklist: Optional[Blacklist] = None
+        blacklist: Optional[Blacklist] = None,
     ) -> "Scenario":
         """
         Makes a :class:`Scenario` out of the provided directory *path*.
@@ -224,7 +232,11 @@ class Scenario:
                 continue
             try:
                 scenario = cls.from_path(
-                    child, plugins, ts_plugins=ts_plugins, short_name=True, blacklist=blacklist
+                    child,
+                    plugins,
+                    ts_plugins=ts_plugins,
+                    short_name=True,
+                    blacklist=blacklist,
                 )
             except SkippableScenarioError as err:
                 logging.warning(
@@ -290,7 +302,7 @@ class Scenario:
         plugins: Sequence[Plugin],
         ts_plugins: Sequence[Plugin],
         short_name: bool,
-        blacklist: Optional[Blacklist] = None
+        blacklist: Optional[Blacklist] = None,
     ) -> "Scenario":
         """
         Creates a Scenario given a HAR file.

--- a/transformer/scenario.py
+++ b/transformer/scenario.py
@@ -28,7 +28,7 @@ import dataclasses
 from dataclasses import dataclass
 
 import transformer.plugins as plug
-from transformer.blacklist import Blacklist
+from transformer.blacklist import Blacklist, get_empty
 from transformer.naming import to_identifier
 from transformer.plugins.contracts import Plugin
 from transformer.request import Request
@@ -124,7 +124,7 @@ class Scenario:
         plugins: Sequence[Plugin] = (),
         ts_plugins: Sequence[Plugin] = (),
         short_name: bool = False,
-        blacklist: Blacklist = set(),
+        blacklist: Optional[Blacklist] = None,
     ) -> "Scenario":
         """
         Makes a :class:`Scenario` (possibly containing sub-scenarios) out of
@@ -149,6 +149,9 @@ class Scenario:
             the parent directory).
         :param blacklist: a set of urls to be blacklisted
         """
+        if blacklist is None:
+            blacklist = get_empty()
+
         if path.is_dir():
             return cls.from_dir(
                 path,

--- a/transformer/task.py
+++ b/transformer/task.py
@@ -293,7 +293,9 @@ class Task(NamedTuple):
     global_code_blocks: Mapping[str, Sequence[str]] = MappingProxyType({})
 
     @classmethod
-    def from_requests(cls, requests: Iterable[Request], blacklist: Optional[Blacklist] = None) -> Iterator["Task"]:
+    def from_requests(
+        cls, requests: Iterable[Request], blacklist: Optional[Blacklist] = None
+    ) -> Iterator["Task"]:
         """
         Generates a set of Tasks from a given set of Requests.
         """

--- a/transformer/task.py
+++ b/transformer/task.py
@@ -294,7 +294,7 @@ class Task(NamedTuple):
 
     @classmethod
     def from_requests(
-        cls, requests: Iterable[Request], blacklist: Optional[Blacklist] = None
+        cls, requests: Iterable[Request], blacklist: Blacklist = set()
     ) -> Iterator["Task"]:
         """
         Generates a set of Tasks from a given set of Requests.

--- a/transformer/task.py
+++ b/transformer/task.py
@@ -42,7 +42,7 @@ import dataclasses
 from dataclasses import dataclass
 
 import transformer.python as py
-from transformer.blacklist import on_blacklist
+from transformer.blacklist import on_blacklist, Blacklist
 from transformer.helpers import zip_kv_pairs
 from transformer.request import HttpMethod, Request, QueryPair
 
@@ -293,13 +293,13 @@ class Task(NamedTuple):
     global_code_blocks: Mapping[str, Sequence[str]] = MappingProxyType({})
 
     @classmethod
-    def from_requests(cls, requests: Iterable[Request]) -> Iterator["Task"]:
+    def from_requests(cls, requests: Iterable[Request], blacklist: Optional[Blacklist] = None) -> Iterator["Task"]:
         """
         Generates a set of Tasks from a given set of Requests.
         """
 
         for req in sorted(requests, key=lambda r: r.timestamp):
-            if on_blacklist(req.url.netloc):
+            if on_blacklist(blacklist, req.url.netloc):
                 continue
             else:
                 yield cls(name=req.task_name(), request=req)

--- a/transformer/task.py
+++ b/transformer/task.py
@@ -42,7 +42,7 @@ import dataclasses
 from dataclasses import dataclass
 
 import transformer.python as py
-from transformer.blacklist import on_blacklist, Blacklist
+from transformer.blacklist import on_blacklist, Blacklist, get_empty
 from transformer.helpers import zip_kv_pairs
 from transformer.request import HttpMethod, Request, QueryPair
 
@@ -294,11 +294,13 @@ class Task(NamedTuple):
 
     @classmethod
     def from_requests(
-        cls, requests: Iterable[Request], blacklist: Blacklist = set()
+        cls, requests: Iterable[Request], blacklist: Optional[Blacklist] = None
     ) -> Iterator["Task"]:
         """
         Generates a set of Tasks from a given set of Requests.
         """
+        if blacklist is None:
+            blacklist = get_empty()
 
         for req in sorted(requests, key=lambda r: r.timestamp):
             if on_blacklist(blacklist, req.url.netloc):

--- a/transformer/test_blacklist.py
+++ b/transformer/test_blacklist.py
@@ -10,7 +10,6 @@ from transformer.blacklist import on_blacklist, from_file as read_blacklist
 
 
 class TestBlacklist:
-
     @patch("builtins.open")
     def test_it_returns_false_and_logs_error_if_the_blacklist_does_not_exist(
         self, mock_open, caplog

--- a/transformer/test_blacklist.py
+++ b/transformer/test_blacklist.py
@@ -6,40 +6,41 @@ import logging
 
 from unittest.mock import patch
 
-from transformer.blacklist import on_blacklist
+from transformer.blacklist import on_blacklist, from_file as read_blacklist
 
 
 class TestBlacklist:
+
     @patch("builtins.open")
     def test_it_returns_false_and_logs_error_if_the_blacklist_does_not_exist(
         self, mock_open, caplog
     ):
         mock_open.side_effect = FileNotFoundError
         caplog.set_level(logging.DEBUG)
-        assert on_blacklist("") is False
+        assert on_blacklist(read_blacklist(), "") is False
         assert f"Could not read blacklist file {os.getcwd()}/.urlignore" in caplog.text
 
     @patch("builtins.open")
     def test_it_returns_false_if_the_blacklist_is_empty(self, mock_open):
         mock_open.return_value = io.StringIO("")
-        assert on_blacklist("") is False
+        assert on_blacklist(read_blacklist(), "") is False
 
     @patch("builtins.open")
     def test_it_returns_false_if_url_is_not_on_blacklist(self, mock_open):
         mock_open.return_value = io.StringIO("www.amazon.com")
-        assert on_blacklist("www.zalando.de") is False
+        assert on_blacklist(read_blacklist(), "www.zalando.de") is False
 
     @patch("builtins.open")
     def test_it_returns_true_if_url_is_on_blacklist(self, mock_open):
         mock_open.return_value = io.StringIO("www.google.com\nwww.amazon.com")
-        assert on_blacklist("www.amazon.com") is True
+        assert on_blacklist(read_blacklist(), "www.amazon.com") is True
 
     @patch("builtins.open")
     def test_it_returns_true_if_a_partial_match_is_found(self, mock_open):
         mock_open.return_value = io.StringIO("www.amazon.com")
-        assert on_blacklist("http://www.amazon.com/") is True
+        assert on_blacklist(read_blacklist(), "http://www.amazon.com/") is True
 
     @patch("builtins.open")
     def test_it_ignores_empty_lines(self, mock_open):
         mock_open.return_value = io.StringIO("\nwww.amazon.com")
-        assert on_blacklist("www.zalando.de") is False
+        assert on_blacklist(read_blacklist(), "www.zalando.de") is False

--- a/transformer/test_request.py
+++ b/transformer/test_request.py
@@ -86,24 +86,14 @@ class TestFromHarEntry:
 
     def test_it_records_har_entry(self):
         entry = {
-            "request": {
-                "method": "GET",
-                "url": "localhost"
-            },
-            "response": {
-                "status": 200,
-                "statusText": "OK",
-            },
+            "request": {"method": "GET", "url": "localhost"},
+            "response": {"status": 200, "statusText": "OK"},
             "cache": {},
-            "timings": {
-              "connect": 22,
-              "wait": 46,
-              "receive": 0
-            },
+            "timings": {"connect": 22, "wait": 46, "receive": 0},
             "startedDateTime": "2018-01-01",
             "time": 116,
             "_securityState": "secure",
-            "connection": "443"
+            "connection": "443",
         }
         request = Request.from_har_entry(entry)
         assert isinstance(request, Request)

--- a/transformer/test_task.py
+++ b/transformer/test_task.py
@@ -364,7 +364,11 @@ class TestReqToExpr:
         url = "http://abc.de"
         name = "my-req"
         r = Request(
-            name=name, timestamp=MagicMock(), method=HttpMethod.GET, url=urlparse(url), har_entry={"entry": "data"}
+            name=name,
+            timestamp=MagicMock(),
+            method=HttpMethod.GET,
+            url=urlparse(url),
+            har_entry={"entry": "data"},
         )
         assert req_to_expr(r) == py.FunctionCall(
             name="self.client.get",
@@ -560,7 +564,7 @@ class TestLreqToExpr:
                 timestamp=MagicMock(),
                 method=HttpMethod.GET,
                 url=urlparse(url),
-                har_entry={"entry": "data"}
+                har_entry={"entry": "data"},
             )
         )
         assert lreq_to_expr(r) == py.FunctionCall(

--- a/transformer/test_task.py
+++ b/transformer/test_task.py
@@ -9,7 +9,7 @@ import pytest
 from hypothesis import given
 from hypothesis.strategies import composite, sampled_from, booleans
 
-from transformer import python as py
+from transformer import python as py, blacklist
 from transformer.request import Header, QueryPair
 from transformer.task import (
     Task,
@@ -45,7 +45,7 @@ class TestTask:
             request = MagicMock()
             request.url = MagicMock()
             request.url.netloc = "www.amazon.com"
-            task = Task.from_requests([request])
+            task = Task.from_requests([request], blacklist=blacklist.from_file())
             assert len(list(task)) == 0
 
         @patch("builtins.open")

--- a/transformer/transform.py
+++ b/transformer/transform.py
@@ -14,6 +14,7 @@ from transformer.locust import locustfile, locustfile_lines
 from transformer.plugins import sanitize_headers, Contract
 from transformer.plugins.contracts import Plugin
 from transformer.scenario import Scenario
+from transformer import blacklist
 
 DEFAULT_PLUGINS = (sanitize_headers.plugin,)
 
@@ -36,7 +37,7 @@ def transform(
     warnings.warn(DeprecationWarning("transform: use dump or dumps instead"))
     if with_default_plugins:
         plugins = (*DEFAULT_PLUGINS, *plugins)
-    return locustfile([Scenario.from_path(Path(scenarios_path), plugins)])
+    return locustfile([Scenario.from_path(Path(scenarios_path), plugins, blacklist=blacklist.from_file())])
 
 
 LaxPath = Union[str, Path]
@@ -96,10 +97,9 @@ def _dump_as_lines(
         plugins = (*DEFAULT_PLUGINS, *plugins)
 
     plugins_for = plug.group_by_contract(plugins)
-
     scenarios = [
         Scenario.from_path(
-            path, plugins_for[Contract.OnTask], plugins_for[Contract.OnTaskSequence]
+            path, plugins_for[Contract.OnTask], plugins_for[Contract.OnTaskSequence], blacklist=blacklist.from_file()
         ).apply_plugins(plugins_for[Contract.OnScenario])
         for path in scenario_paths
     ]

--- a/transformer/transform.py
+++ b/transformer/transform.py
@@ -37,7 +37,13 @@ def transform(
     warnings.warn(DeprecationWarning("transform: use dump or dumps instead"))
     if with_default_plugins:
         plugins = (*DEFAULT_PLUGINS, *plugins)
-    return locustfile([Scenario.from_path(Path(scenarios_path), plugins, blacklist=blacklist.from_file())])
+    return locustfile(
+        [
+            Scenario.from_path(
+                Path(scenarios_path), plugins, blacklist=blacklist.from_file()
+            )
+        ]
+    )
 
 
 LaxPath = Union[str, Path]
@@ -99,7 +105,10 @@ def _dump_as_lines(
     plugins_for = plug.group_by_contract(plugins)
     scenarios = [
         Scenario.from_path(
-            path, plugins_for[Contract.OnTask], plugins_for[Contract.OnTaskSequence], blacklist=blacklist.from_file()
+            path,
+            plugins_for[Contract.OnTask],
+            plugins_for[Contract.OnTaskSequence],
+            blacklist=blacklist.from_file(),
         ).apply_plugins(plugins_for[Contract.OnScenario])
         for path in scenario_paths
     ]


### PR DESCRIPTION
One-line summary.

Closes #23 

## Description

Refactor blacklisting mechanism so that the file is only read once. 

Unfortunately adding yet another parameter seems like the only viable option. I tried another approach with calling `from_file()` directly in the `blacklist` module, which seems like an interesting approach to hide the implementation from other modules. However this made the functionality more or less untestable, so I chose to go with the parameter approach.

## Types of Changes
- Refactor/improvements

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.


