### PR TITLE
Fix pushing tags: overwrite if tag already exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_deploy:
 - git config --local user.name "$GITHUB_USERNAME"
 - git config --local user.email "$GITHUB_EMAIL"
 - export TRAVIS_TAG=v$(poetry run transformer --version)
-- git tag $TRAVIS_TAG
+- git tag --force $TRAVIS_TAG
 deploy:
   # Main releases: tags set on master
   - provider: script

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,6 +15,22 @@ The format is based on `Keep a Changelog`_, and this project adheres to
    :local:
    :depth: 1
 
+.. _v1.2.3:
+
+v1.2.3
+======
+
+- Release date: 2019-05-03 16:03
+
+- Diff__.
+
+__ https://github.com/zalando-incubator/transformer/compare/v1.2.2...v1.2.3
+
+Changed
+-------
+
+No functional changes in Transformer! Fixed: pushing tagged releases to Github.
+
 .. _v1.2.2:
 
 v1.2.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ author = "the Zalando maintainers"
 # The short X.Y version
 version = "1.2"
 # The full version, including alpha/beta/rc tags
-release = "1.2.2"
+release = "1.2.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "har-transformer"
-version = "1.2.2"
+version = "1.2.3"
 description = "A tool to convert HAR files into a locustfile."
 authors = [
     "Serhii Cherniavskyi <serhii.cherniavskyi@zalando.de>",


### PR DESCRIPTION
Signed-off-by: Oliwia Zaremba <oliwia.zaremba@zalando.de>

No functional changes! 

Post-fix to #50 

## Description

This PR aims to fix the error on Travis ([as seen here](https://travis-ci.org/zalando-incubator/Transformer/jobs/527689045)) where `git tag` fails because: `fatal: tag 'v1.2.2' already exists`
## Types of Changes
- Configuration change

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.

## After this PR

Check if build on Travis passes and the tag `v1.2.3` is created and visible on GitHub.