### PR TITLE
locust_taskset: take Task2 into account when checking for Task

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,6 +15,25 @@ The format is based on `Keep a Changelog`_, and this project adheres to
    :local:
    :depth: 1
 
+.. _v1.2.5:
+
+v1.2.5
+======
+
+- Release date: 2019-09-02 12:00
+
+- Diff__.
+
+__ https://github.com/zalando-incubator/transformer/compare/v1.2.4...v1.2.5
+
+Fixed
+-----
+
+The generated scenario classes always inherit from
+:class:`~locust.TaskSequence` (instead of a :class:`~locust.TaskSet`) when they
+use the `@seq_task` decorator.
+Thank you :user:`kbrowns` for reporting this! (:pr:`62`)
+
 .. _v1.2.4:
 
 v1.2.4

--- a/docs/Creating-HAR-files.rst
+++ b/docs/Creating-HAR-files.rst
@@ -27,7 +27,7 @@ Record a scenario
 -----------------
 
 #. **Prepare your scenario** by thinking through the steps you want to execute.
-#. Open Chrome in either **Gest** or **Incognito** mode (it's important to have
+#. Open Chrome in either **Guest** or **Incognito** mode (it's important to have
    no cookies prior to starting).
 #. Open the `Developer Tools`_.
 #. Open the **Network** panel.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ author = "the Zalando maintainers"
 # The short X.Y version
 version = "1.2"
 # The full version, including alpha/beta/rc tags
-release = "1.2.4"
+release = "1.2.5"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "har-transformer"
-version = "1.2.4"
+version = "1.2.5"
 description = "A tool to convert HAR files into a locustfile."
 authors = [
     "Serhii Cherniavskyi <serhii.cherniavskyi@zalando.de>",

--- a/transformer/locust.py
+++ b/transformer/locust.py
@@ -45,7 +45,7 @@ def locust_taskset(scenario: Scenario) -> py.Class:
     Transforms a scenario (potentially containing other scenarios) into a Locust
     TaskSet definition.
     """
-    if any(isinstance(child, Task) for child in scenario.children):
+    if any(isinstance(child, (Task, Task2)) for child in scenario.children):
         ts_type = TaskSetType.Sequence
     else:
         ts_type = TaskSetType.Set


### PR DESCRIPTION
Fixes #61.

## Description

Until `Task2` completely replaces `Task`, both need to be treated the same way, as they represent the same data. In this particular function, they are treated the same way, save for a single statement, which caused the reported issue (#61).

Verified over `examples/en.zalando.de.har` (before/after).

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

## TODO

_List of tasks you will do to complete the PR:_

- [x] Bump version

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.
