### PR TITLE
Append current directory to the Python sys.path

### DIFF
--- a/transformer/plugins/resolve.py
+++ b/transformer/plugins/resolve.py
@@ -1,6 +1,8 @@
 import importlib
 import inspect
 import logging
+import sys
+from os import getcwd
 from types import ModuleType
 from typing import Iterator
 
@@ -27,6 +29,7 @@ def resolve(name: str) -> Iterator[Plugin]:
     :raise InvalidContractError: from load_load_plugins_from_module.
     :raise NoPluginError: from load_load_plugins_from_module.
     """
+    sys.path.append(getcwd())
     module = importlib.import_module(name)
 
     yield from load_plugins_from_module(module)


### PR DESCRIPTION
Append current directory to the Python sys.path to allow using plugins that have not been installed using pypi

Closes #56

## Description

According to https://github.com/zalando-incubator/Transformer/blob/master/docs/Using-plugins.rst, together with https://transformer.readthedocs.io/en/latest/Writing-plugins.html#name-resolution ,  when using the cli, 
`transformer  -p mod.sub har/ >loc.py ` should work for a plugin called `sub.py` located in the `mod` directory.
However this didn't work unless the plugin has not been installed in the Python sys.path. Plugins left in the directory where transformer is executed are not found. Adding the current dir to the sys path fixes it.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
Adds the current path to the sys.path where Transformer can look for plugins


## Review

1. Anywhere in your system, creates a dummy.py plugin file
2- Run Transformer with the -p python_path argument
3. See error before appying this PR and see there's no error after this PR is applied


## After this PR

Document at https://transformer.readthedocs.io/en/latest/Writing-plugins.html#name-resolution that this solves the problem when the plugin is in the current directory but not if it's somewhere else.
