### PR TITLE
Fix log destination

### DIFF
--- a/tests/functional/test_examples.py
+++ b/tests/functional/test_examples.py
@@ -2,11 +2,15 @@ import subprocess
 from pathlib import Path
 
 
-def run_example(example_name: str) -> subprocess.CompletedProcess:
+def run_example(example_name: str, **subprocess_opts) -> subprocess.CompletedProcess:
     har_path = Path(__file__).parent.parent.parent.joinpath("examples", example_name)
-    return subprocess.run(
-        ["transformer", str(har_path)], timeout=2, check=True, stdout=subprocess.PIPE
-    )
+    subprocess_opts = {
+        "timeout": 2,
+        "check": True,
+        "stdout": subprocess.PIPE,
+        **subprocess_opts,
+    }
+    return subprocess.run(["transformer", str(har_path)], **subprocess_opts)
 
 
 def test_example_google():
@@ -19,3 +23,12 @@ def test_example_zalando():
     ex = run_example("en.zalando.de.har")
     assert len(ex.stdout) > 100
     assert b"https://en.zalando.de/?_rfl=de" in ex.stdout
+
+
+def test_logs_in_stderr():
+    ex = run_example(
+        "en.zalando.de.har", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    assert len(ex.stdout) > 100
+    assert b"INFO" not in ex.stdout
+    assert b"INFO" in ex.stderr


### PR DESCRIPTION
Make sure that logs from Transformer are not emitted on the same stream (stdout) than the generated code.

Closes #65.

## Description

Transformer should send its logs to stderr, so that users can reliably do something like `transformer my.har >my.py` and trust that `my.py` is a valid Python file.

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- ~New feature (non-breaking change which adds functionality)~
- Bug fix (non-breaking change which fixes an issue)
- ~Configuration change~
- ~Refactor/improvements~
- ~Documentation / non-code~

## TODO

_List of tasks you will do to complete the PR:_

- [ ] Add a test demonstrating the problem.
- [ ] Fix the problem.

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.

## After this PR

Any follow-up action necessary?
