### PR TITLE
changed min_wait/max_wait into between(min_wait,max_wait)

### DIFF
--- a/tests/transformer/test_locust.py
+++ b/tests/transformer/test_locust.py
@@ -43,6 +43,7 @@ from locust import TaskSequence
 from locust import TaskSet
 from locust import seq_task
 from locust import task
+from locust import between
 class ScenarioGroup(TaskSet):
     @task(1)
     class SomeScenario(TaskSequence):
@@ -52,8 +53,7 @@ class ScenarioGroup(TaskSet):
 class LocustForScenarioGroup(HttpLocust):
     task_set = ScenarioGroup
     weight = 2
-    min_wait = 0
-    max_wait = 10
+    wait_time = between(0, 10)
 """
         ).safe_substitute({"TIMEOUT": TIMEOUT})
         assert expected.strip() == script.strip()
@@ -91,6 +91,7 @@ from locust import TaskSequence
 from locust import TaskSet
 from locust import seq_task
 from locust import task
+from locust import between
 class ScenarioGroup(TaskSet):
     @task(1)
     class SomeScenario(TaskSequence):
@@ -100,8 +101,7 @@ class ScenarioGroup(TaskSet):
 class LocustForScenarioGroup(HttpLocust):
     task_set = ScenarioGroup
     weight = 2
-    min_wait = 0
-    max_wait = 10
+    wait_time = between(0, 10)
 """
         ).safe_substitute({"TIMEOUT": TIMEOUT})
         assert expected.strip() == script.strip()

--- a/transformer/locust.py
+++ b/transformer/locust.py
@@ -90,8 +90,7 @@ def locust_classes(scenarios: Sequence[Scenario]) -> List[py.Class]:
             statements=[
                 py.Assignment("task_set", py.Symbol(taskset.name)),
                 py.Assignment("weight", py.Literal(scenario.weight)),
-                py.Assignment("min_wait", py.Literal(LOCUST_MIN_WAIT_DELAY)),
-                py.Assignment("max_wait", py.Literal(LOCUST_MAX_WAIT_DELAY)),
+                py.Assignment("wait_time", py.FunctionCall( name = "between", positional_args = [py.Literal(LOCUST_MIN_WAIT_DELAY), py.Literal(LOCUST_MAX_WAIT_DELAY)])),
             ],
         )
         classes.append(taskset)
@@ -114,7 +113,7 @@ def locust_program(scenarios: Sequence[Scenario]) -> py.Program:
     return [
         py.Import(["re"], comments=[LOCUSTFILE_COMMENT]),
         py.Import(
-            ["HttpLocust", "TaskSequence", "TaskSet", "seq_task", "task"],
+            ["HttpLocust", "TaskSequence", "TaskSet", "seq_task", "task", "between"],
             source="locust",
         ),
         *locust_classes(scenarios),


### PR DESCRIPTION
changed min_wait/max_wait into between(min_wait,max_wait)

## Description

The min_wait/max_wait don't work with the current locust.io, so I changed them into `between()`, so
that `transformer` generates a "locustfile.py" that can be used directly without manual editing.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
- I also updated the tests so that they run fine.
