### PR TITLE
Add support for regexes in url ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,7 @@ venv.bak/
 
 # Project files
 examples/locustfile.py
-.urlignore
+.ignore
 
 # Generated files
 coverage_results

--- a/docs/Ignoring-urls.rst
+++ b/docs/Ignoring-urls.rst
@@ -5,28 +5,30 @@
 
 By default, Transformer converts *all* requests found in the HAR files you
 provide.
-However, you can **ignore** certain URLs by creating a
-``.urlignore`` file in the directory in which Transformer is executed.
+However, you can **ignore** certain URLs by creating an
+``.ignore`` file in the directory in which Transformer is executed.
+
+The file supports regular expressions.
 
 Example
 -------
 
-A ``.urlignore`` containing::
+An ``.ignore`` file containing::
 
    google
-   www.facebook.com
    https://mosaic
+   .*/foo.gif
 
 ... would ignore requests with URLs such as:
 
 - ``https://www.google.com``,
-- ``https://www.facebook.com/``,
 - ``https://mosaic01-abc.js``,
+- ``https://anything.com/foo.gif``,
 - ... and more following the same patterns.
 
-We provide an example denylist file called `.urlignore_example`_ that you can
+We provide an example denylist file called `.ignore_example`_ that you can
 use as a base.
-Note that it needs to be **renamed** ``.urlignore`` for Transformer to take it
+Note that it needs to be **renamed** ``.ignore`` for Transformer to take it
 into account.
 
-.. _.urlignore_example: https://github.com/zalando-incubator/Transformer/blob/master/transformer/.urlignore_example
+.. _.ignore_example: https://github.com/zalando-incubator/Transformer/blob/master/transformer/.ignore_example

--- a/tests/transformer/test_denylist.py
+++ b/tests/transformer/test_denylist.py
@@ -17,7 +17,7 @@ class TestDenylist:
         denylist = read_denylist()
         assert len(denylist) == 0
         assert on_denylist(denylist, "whatever") is False
-        assert f"Could not read denylist file {os.getcwd()}/.urlignore" in caplog.text
+        assert f"Could not read denylist file {os.getcwd()}/.ignore" in caplog.text
 
     def test_it_returns_false_if_the_denylist_is_empty(self, mock_open):
         mock_open.return_value = io.StringIO("")

--- a/tests/transformer/test_denylist.py
+++ b/tests/transformer/test_denylist.py
@@ -42,3 +42,10 @@ class TestDenylist:
     def test_it_removes_duplicate_entries(self, mock_open):
         mock_open.return_value = io.StringIO("\nwww.amazon.com" * 3)
         assert len(read_denylist()) == 1
+
+    def test_it_returns_true_if_url_matches_regex(self, mock_open):
+        mock_open.return_value = io.StringIO("www.google.com\nwww.ama.*com")
+        denylist = read_denylist()
+        assert on_denylist(denylist, "www.amazon.com") is True
+        assert on_denylist(denylist, "www.google.com") is True
+        assert on_denylist(denylist, "www.goog.com") is False

--- a/transformer/.ignore_example
+++ b/transformer/.ignore_example
@@ -66,3 +66,4 @@ vmg.host
 yieldlab.net
 ztat.net
 admatic.com
+.*/ignore_some_image.gif

--- a/transformer/denylist.py
+++ b/transformer/denylist.py
@@ -11,7 +11,11 @@ def get_empty() -> Denylist:
 
 
 def from_file() -> Denylist:
-    denylist_file = f"{os.getcwd()}/.urlignore"
+    if os.path.exists(f"{os.getcwd()}/.urlignore"):
+        logging.warning(
+            "Legacy .urlignore file detected - it will not be used! Rename it to '.ignore' if you want to use it."
+        )
+    denylist_file = f"{os.getcwd()}/.ignore"
     try:
         with open(denylist_file, encoding="utf-8") as file:
             return set(filter(None, [line.rstrip() for line in file]))

--- a/transformer/denylist.py
+++ b/transformer/denylist.py
@@ -1,3 +1,4 @@
+import warnings
 import logging
 import os
 from typing import Set
@@ -12,7 +13,7 @@ def get_empty() -> Denylist:
 
 def from_file() -> Denylist:
     if os.path.exists(f"{os.getcwd()}/.urlignore"):
-        logging.warning(
+        warnings.warn(
             "Legacy .urlignore file detected - it will not be used! Rename it to '.ignore' if you want to use it, and read about the difference in the documentation."
         )
     denylist_file = f"{os.getcwd()}/.ignore"

--- a/transformer/denylist.py
+++ b/transformer/denylist.py
@@ -13,7 +13,7 @@ def get_empty() -> Denylist:
 def from_file() -> Denylist:
     if os.path.exists(f"{os.getcwd()}/.urlignore"):
         logging.warning(
-            "Legacy .urlignore file detected - it will not be used! Rename it to '.ignore' if you want to use it."
+            "Legacy .urlignore file detected - it will not be used! Rename it to '.ignore' if you want to use it, and read about the difference in the documentation."
         )
     denylist_file = f"{os.getcwd()}/.ignore"
     try:

--- a/transformer/denylist.py
+++ b/transformer/denylist.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from typing import Set
+import re
 
 Denylist = Set[str]
 
@@ -25,6 +26,6 @@ def on_denylist(denylist: Denylist, url: str) -> bool:
     from user's current directory.
     """
     for denylist_item in denylist:
-        if denylist_item in url:
+        if re.search(denylist_item, url):
             return True
     return False

--- a/transformer/task.py
+++ b/transformer/task.py
@@ -164,7 +164,7 @@ class Task2:
         #   See what is done in from_task (but without the LocustRequest part).
         #   See https://github.com/zalando-incubator/Transformer/issues/11.
         for req in sorted(requests, key=lambda r: r.timestamp):
-            if not on_denylist(req.url.netloc):
+            if not on_denylist(req.url.geturl()):
                 yield cls(name=req.task_name(), request=req, statements=...)
 
     @classmethod
@@ -301,7 +301,7 @@ class Task(NamedTuple):
             denylist = get_empty()
 
         for req in sorted(requests, key=lambda r: r.timestamp):
-            if on_denylist(denylist, req.url.netloc):
+            if on_denylist(denylist, req.url.geturl()):
                 continue
             else:
                 yield cls(name=req.task_name(), request=req)


### PR DESCRIPTION
Fixes #81.

## Description

I didnt find an easy way to ignore requests entirely by using plugins, and just using string matching is not flexible enough. Could be a breaking change in rare cases, but should work in most cases.

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)

## TODO

_List of tasks you will do to complete the PR:_

- [x] Add example and update documentation (will do this if you think the change is a good idea)