### PR TITLE
Enable editable installations: pip install -e .

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[options]
+packages = transformer
+
+[options.entry_points]
+console_scripts =
+    transformer = transformer.cli:script_entrypoint


### PR DESCRIPTION
Maybe there is some other way to make editable installations, but `pip install -e ...` is the only way I know, and a setup.cfg or setup.py file is needed for that :)

Fixes #85