### PR TITLE
Fix dataclass issues for Python 3.11

### DIFF
--- a/transformer/request.py
+++ b/transformer/request.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse, SplitResult
 from requests.structures import CaseInsensitiveDict
 
 import pendulum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from transformer.naming import to_identifier
 
@@ -118,7 +118,7 @@ requests-to-urls-with-dynamic-parameters
     method: HttpMethod
     url: SplitResult
     har_entry: dict
-    headers: CaseInsensitiveDict = MappingProxyType({})
+    headers: CaseInsensitiveDict = field(default_factory=lambda: MappingProxyType({}))
     post_data: Optional[dict] = None
     query: List[QueryPair] = ()
     name: Optional[str] = None

--- a/transformer/task.py
+++ b/transformer/task.py
@@ -39,14 +39,14 @@ from typing import (
 )
 
 import dataclasses
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from requests.structures import CaseInsensitiveDict
 
 import transformer.python as py
 from transformer.denylist import on_denylist, Denylist, get_empty
 from transformer.request import HttpMethod, Request, QueryPair
 
-IMMUTABLE_EMPTY_DICT = MappingProxyType({})
+IMMUTABLE_EMPTY_DICT = field(default_factory=lambda: MappingProxyType({}))
 TIMEOUT = 30
 ACTION_INDENTATION_LEVEL = 12
 JSON_MIME_TYPE = "application/json"


### PR DESCRIPTION
This PR adds Python 3.11 support.

Closes #88.

## Description

Transformer doesn't work in Python 3.11, due to breaking changes in dataclasses (https://github.com/python/cpython/issues/99401). Namely, the default values for dataclass fields must be hashable. In the Transformer codebase, `MappingProxyType` is used, which isn't hashable. This PR fixes those issues, by using `default_factory` to get around this issue.

## Types of Changes

_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

## Review

_Reviewers' checklist:_

- If this PR _implements_ new flows or _changes_ existing ones, are there
  **good tests** for these flows?
  If this PR rather _removes_ flows, are the obsolete tests removed as well?
- Is the documentation still up-to-date and exhaustive? This covers both
  _technical_ (in source files) and _functional_ (under `docs/`) documentation.
- Is the **changelog** updated?
- Does the **new version number** correspond to the actual changes from this PR?
  In doubt, refer to https://semver.org.

## After this PR

Any follow-up action necessary?
